### PR TITLE
Add support for automatic sunset and sunrise detection via {suncalc}

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ Imports:
     rstudioapi (>= 0.9.0)
 Suggests: 
     sass (>= 0.1.0),
+    suncalc,
     whisker
 Encoding: UTF-8
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,9 +19,12 @@ Imports:
     purrr,
     rstudioapi (>= 0.9.0)
 Suggests: 
+    ipapi (>= 0.1),
     sass (>= 0.1.0),
     suncalc,
     whisker
+Remotes: 
+    hrbrmstr/ipapi
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)

--- a/R/auto.R
+++ b/R/auto.R
@@ -30,6 +30,8 @@
 #'   setHook("rstudio.sessionInit", function(isNewSession) {
 #'     # Automatically choose the correct theme based on time of day
 #'     rsthemes::use_theme_auto(dark_start = "18:00", dark_end = "6:00")
+#'     # Alternatively use a dynamic solution based on your location
+#'     # rsthemes::use_theme_auto(lat = 50.30, lon = 9.40)
 #'   }, action = "append")
 #' }
 #' ```
@@ -70,6 +72,8 @@
 #' @param quietly Suppress confirmation messages
 #' @param dark_start Start time of dark mode, in 24-hour `"HH:MM"` format.
 #' @param dark_end End time of dark mode, in 24-hour `"HH:MM"` format.
+#' @param lat Latitude of your current location.
+#' @param lon Longitude of your current location.
 #' @name auto_theme
 NULL
 

--- a/R/auto.R
+++ b/R/auto.R
@@ -30,15 +30,27 @@
 #'   setHook("rstudio.sessionInit", function(isNewSession) {
 #'     # Automatically choose the correct theme based on time of day
 #'     rsthemes::use_theme_auto(dark_start = "18:00", dark_end = "6:00")
+#'
 #'     # Alternatively use a dynamic solution based on your location
 #'     # rsthemes::use_theme_auto(lat = 50.30, lon = 9.40)
+#'
+#'     # Or alternatively use {ipapi} to determine your location automatically
+#'     # rsthemes::use_theme_auto()
 #'   }, action = "append")
 #' }
 #' ```
 #'
-#' If you'd rather not use this approach, you can simply declare the global
-#' options that declare the default themes, but you won't be able to use
-#' [use_theme_auto()] at startup.
+#' Note that the fully automated approach will use
+#' [ip-api.com](https://ip-api.com/) to look up your current location using your
+#' IP address (if the \pkg{ipapi} package is available). If you'd like to use
+#' geolocation but without pining an external server, you can call
+#' `rsthemes:::geolocate()` once to determine your approximate latitude and
+#' longitude. Your location coordinates are cached on a per-project basis and
+#' checked once per day (per project).
+#'
+#' Here are two other approaches that you can use. Both set the global
+#' options that declare the default themes, but rely on you manually calling
+#' [use_theme_auto()] or the Auto Dark/Light addin.
 #'
 #' ```
 #' # ~/.Rprofile
@@ -192,37 +204,140 @@ use_theme_toggle <- function(quietly = FALSE) {
 
 #' @describeIn auto_theme Auto switch between dark and light themes
 #' @export
-use_theme_auto <- function(dark_start = NULL, dark_end = NULL,
-                           lat = NULL, lon = NULL, quietly = FALSE) {
+use_theme_auto <- function(
+  dark_start = NULL,
+  dark_end = NULL,
+  lat = NULL,
+  lon = NULL,
+  quietly = FALSE
+) {
 
-  if (!is.null(lat) && !is.null(lon)) {
-    requireNamespace("suncalc", quietly = TRUE)
-    times <- suncalc::getSunlightTimes(lat = lat, lon = lon, date = Sys.Date())
-    dark_end <- hms::as_hms(times$sunrise)
-    dark_start <- hms::as_hms(times$sunset)
-  } else {
-    dark_start <- hms::parse_hm(dark_start)
-    dark_end <- hms::parse_hm(dark_end)
+  dark_times <- list(start = dark_start, end = dark_end)
+  coords <- list(lat = lat, lon = lon)
+
+  n_times <- sum(is_null(dark_times))
+  n_coords <- sum(is_null(coords))
+
+  has_times <- n_times == 0
+
+  if (n_times == 1) {
+    cli::cli_alert_warning(
+      "[rsthemes] {.fn use_theme_auto} requires both {.code dark_start} and {.code dark_end} or neither"
+    )
   }
+  if (n_coords == 1) {
+    cli::cli_alert_warning(
+      "[rsthemes] {.fn use_theme_auto} requires both {.code lat} and {.code lot} or neither"
+    )
+    coords <- list(lat = NULL, lon = NULL)
+  }
+
+  if (!has_times) {
+    dark_times <- local_daylight_hours(coords$lat, coords$lon, quietly = quietly)
+  }
+
+  if (any(is_null(dark_times))) {
+    dark_times <- list(
+      end   = dark_end   %||% dark_times$end   %||% "18:00",
+      start = dark_start %||% dark_times$start %||% "6:00"
+    )
+  }
+
+  dark_times <- lapply(dark_times, hms::as_hms)
   now <- hms::as_hms(Sys.time())
 
   pre_start <- use_theme_dark
 
-  if (dark_end > dark_start) {
+  if (dark_times$end > dark_times$start) {
     # if light mode overnight, swap dark start/end
-    .dark_start <- dark_start
-    dark_start <- dark_end
-    dark_end <- .dark_start
+    .dark_start <- dark_times$start
+    dark_times$start <- dark_times$end
+    dark_times$end <- .dark_start
     pre_start <- use_theme_light
   }
 
-  if (now > dark_start) {
+  if (now > dark_times$start) {
     use_theme_dark(quietly)
-  } else if (now > dark_end) {
+  } else if (now > dark_times$end) {
     use_theme_light(quietly)
   } else {
     pre_start(quietly)
   }
+}
+
+local_daylight_hours <- function(lat = NULL, lon = NULL, quietly = FALSE) {
+  coords <- list(lat = lat, lon = lon)
+  if (any(is_null(coords))) {
+    coords <- geolocate(quietly = quietly)
+  }
+  if (all(is_null(coords))) {
+    return(coords)
+  }
+  if (!requireNamespace("suncalc", quietly = TRUE)) {
+    stop("`suncalc` is required: install.packages('suncalc')")
+  }
+  times <- suncalc::getSunlightTimes(
+    lat = coords$lat,
+    lon = coords$lon,
+    date = Sys.Date(),
+    tz = Sys.getenv("TZ")
+  )
+  list(
+    end = times$sunrise,
+    start = times$sunset
+  )
+}
+
+geolocate <- function(quietly = FALSE) {
+  if (!requireNamespace("ipapi", quietly = TRUE)) {
+    stop("`ipapi` is required: devtools::install_github('hrbrmstr/ipapi')")
+  }
+
+  cache <- geolocate_get_cache()
+
+  if (!is.null(cache)) {
+    return(cache)
+  }
+
+  if (!quietly) cli::cli_process_start("[rsthemes] Determining your location from you IP via {.pkg ipapi}")
+  x <- ipapi::geolocate(NA, .progress = FALSE)
+  if (!quietly) cli::cli_process_done()
+
+  if (identical(x$status, "success")) {
+    geolocate_set_cache(x$lat, x$lon)
+    list(lat = x$lat, lon = x$lon)
+  }
+}
+
+geolocate_get_cache <- function() {
+  cache_time <- rstudioapi::getPersistentValue("rsthemes.geolocate.time")
+  cache_invalid <- is.null(cache_time)
+
+  if (!cache_invalid) {
+    cache_invalid <- (Sys.time() - as.integer(cache_time)) > 60 * 60 * 24
+  }
+
+  if (cache_invalid) {
+    rstudioapi::setPersistentValue("rsthemes.geolocate.time", NULL)
+    return(NULL)
+  }
+
+  list(
+    lat = rstudioapi::getPersistentValue("rsthemes.geolocate.lat"),
+    lon = rstudioapi::getPersistentValue("rsthemes.geolocate.lon")
+  )
+}
+
+geolocate_set_cache <- function(lat, lon) {
+  rstudioapi::setPersistentValue("rsthemes.geolocate.time", Sys.time())
+  rstudioapi::setPersistentValue("rsthemes.geolocate.lat", lat)
+  rstudioapi::setPersistentValue("rsthemes.geolocate.lon", lon)
+}
+
+geolocate_clear_cache <- function() {
+  rstudioapi::setPersistentValue("rsthemes.geolocate.time", NULL)
+  rstudioapi::setPersistentValue("rsthemes.geolocate.lat", NULL)
+  rstudioapi::setPersistentValue("rsthemes.geolocate.lon", NULL)
 }
 
 #' @describeIn auto_theme Walk through a list of favorite themes

--- a/R/auto.R
+++ b/R/auto.R
@@ -43,10 +43,11 @@
 #' Note that the fully automated approach will use
 #' [ip-api.com](https://ip-api.com/) to look up your current location using your
 #' IP address (if the \pkg{ipapi} package is available). If you'd like to use
-#' geolocation but without pining an external server, you can call
+#' geolocation but without pinging an external server, you can call
 #' `rsthemes:::geolocate()` once to determine your approximate latitude and
-#' longitude. Your location coordinates are cached on a per-project basis and
-#' checked once per day (per project).
+#' longitude, which you can provide to [use_theme_auto()]. Your location
+#' coordinates are cached on a per-project basis and only checked once per day
+#' (per project).
 #'
 #' Here are two other approaches that you can use. Both set the global
 #' options that declare the default themes, but rely on you manually calling

--- a/R/auto.R
+++ b/R/auto.R
@@ -271,7 +271,7 @@ local_daylight_hours <- function(lat = NULL, lon = NULL, quietly = FALSE) {
     coords <- geolocate(quietly = quietly)
   }
   if (all(is_null(coords))) {
-    return(coords)
+    return(list(end = NULL, start = NULL))
   }
   if (!requireNamespace("suncalc", quietly = TRUE)) {
     stop("`suncalc` is required: install.packages('suncalc')")

--- a/R/auto.R
+++ b/R/auto.R
@@ -267,11 +267,12 @@ use_theme_auto <- function(
 
 local_daylight_hours <- function(lat = NULL, lon = NULL, quietly = FALSE) {
   coords <- list(lat = lat, lon = lon)
+  null_times <- list(end = NULL, start = NULL)
   if (any(is_null(coords))) {
-    coords <- geolocate(quietly = quietly)
+    coords <- purrr::possibly(geolocate, null_times)(quietly = quietly)
   }
   if (all(is_null(coords))) {
-    return(list(end = NULL, start = NULL))
+    return(null_times)
   }
   if (!requireNamespace("suncalc", quietly = TRUE)) {
     stop("`suncalc` is required: install.packages('suncalc')")

--- a/R/auto.R
+++ b/R/auto.R
@@ -108,7 +108,9 @@ set_theme_favorite <- function(theme = NULL, append = TRUE) {
 
 get_or_check_theme <- function(theme = NULL, style = NULL) {
   if (is.null(theme)) {
-    if (!in_rstudio()) return(NULL)
+    if (!in_rstudio()) {
+      return(NULL)
+    }
     theme <- get_current_theme_name()
   }
   if (in_rstudio()) {
@@ -141,7 +143,9 @@ use_theme_light <- function(quietly = FALSE) use_theme("light", quietly)
 use_theme_dark <- function(quietly = FALSE) use_theme("dark", quietly)
 
 use_theme <- function(style = c("light", "dark"), quietly = FALSE) {
-  if (!in_rstudio()) return(invisible())
+  if (!in_rstudio()) {
+    return(invisible())
+  }
 
   theme <- switch(
     match.arg(style),
@@ -184,9 +188,18 @@ use_theme_toggle <- function(quietly = FALSE) {
 
 #' @describeIn auto_theme Auto switch between dark and light themes
 #' @export
-use_theme_auto <- function(dark_start = "18:00", dark_end = "6:00", quietly = FALSE) {
-  dark_start <- hms::parse_hm(dark_start)
-  dark_end <- hms::parse_hm(dark_end)
+use_theme_auto <- function(dark_start = NULL, dark_end = NULL,
+                           lat = NULL, lon = NULL, quietly = FALSE) {
+
+  if (!is.null(lat) && !is.null(lon)) {
+    requireNamespace("suncalc", quietly = TRUE)
+    times <- suncalc::getSunlightTimes(lat = lat, lon = lon, date = Sys.Date())
+    dark_end <- hms::as_hms(times$sunrise)
+    dark_start <- hms::as_hms(times$sunset)
+  } else {
+    dark_start <- hms::parse_hm(dark_start)
+    dark_end <- hms::parse_hm(dark_end)
+  }
   now <- hms::as_hms(Sys.time())
 
   pre_start <- use_theme_dark
@@ -258,8 +271,12 @@ stop_if_theme_not_set <- function(theme_opt = NULL, style = c("light", "dark")) 
 }
 
 stop_if_theme_not_valid <- function(theme) {
-  if (!in_rstudio()) return(theme)
-  if (theme %in% get_theme_names()) return(theme)
+  if (!in_rstudio()) {
+    return(theme)
+  }
+  if (theme %in% get_theme_names()) {
+    return(theme)
+  }
   stop("'", theme, '" is not the name of an installed theme.', call. = FALSE)
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,5 +1,9 @@
 `%||%` <- function(x, y) if (is.null(x)) y else x
 
+is_null <- function(x) {
+  vapply(x, is.null, logical(1))
+}
+
 requires_rstudioapi <- function(..., has_fun = "getThemes", version = "1.2.1335") {
   if (!requireNamespace("rstudioapi", quietly = TRUE)) {
     stop("The {rstudioapi} package is required")

--- a/man/auto_theme.Rd
+++ b/man/auto_theme.Rd
@@ -100,15 +100,27 @@ declare your default themes:\preformatted{if (interactive() && requireNamespace(
   setHook("rstudio.sessionInit", function(isNewSession) \{
     # Automatically choose the correct theme based on time of day
     rsthemes::use_theme_auto(dark_start = "18:00", dark_end = "6:00")
+
     # Alternatively use a dynamic solution based on your location
     # rsthemes::use_theme_auto(lat = 50.30, lon = 9.40)
+
+    # Or alternatively use \{ipapi\} to determine your location automatically
+    # rsthemes::use_theme_auto()
   \}, action = "append")
 \}
 }
 
-If you'd rather not use this approach, you can simply declare the global
-options that declare the default themes, but you won't be able to use
-\code{\link[=use_theme_auto]{use_theme_auto()}} at startup.\preformatted{# ~/.Rprofile
+Note that the fully automated approach will use
+\href{https://ip-api.com/}{ip-api.com} to look up your current location using your
+IP address (if the \pkg{ipapi} package is available). If you'd like to use
+geolocation but without pining an external server, you can call
+\code{rsthemes:::geolocate()} once to determine your approximate latitude and
+longitude. Your location coordinates are cached on a per-project basis and
+checked once per day (per project).
+
+Here are two other approaches that you can use. Both set the global
+options that declare the default themes, but rely on you manually calling
+\code{\link[=use_theme_auto]{use_theme_auto()}} or the Auto Dark/Light addin.\preformatted{# ~/.Rprofile
 rsthemes::set_theme_light("One Light \{rsthemes\}")
 rsthemes::set_theme_dark("One Dark \{rsthemes\}")
 rsthemes::set_theme_favorite(c(

--- a/man/auto_theme.Rd
+++ b/man/auto_theme.Rd
@@ -24,7 +24,13 @@ use_theme_dark(quietly = FALSE)
 
 use_theme_toggle(quietly = FALSE)
 
-use_theme_auto(dark_start = "18:00", dark_end = "6:00", quietly = FALSE)
+use_theme_auto(
+  dark_start = NULL,
+  dark_end = NULL,
+  lat = NULL,
+  lon = NULL,
+  quietly = FALSE
+)
 
 use_theme_favorite(quietly = FALSE)
 }
@@ -40,6 +46,10 @@ favorite themes.}
 \item{dark_start}{Start time of dark mode, in 24-hour \code{"HH:MM"} format.}
 
 \item{dark_end}{End time of dark mode, in 24-hour \code{"HH:MM"} format.}
+
+\item{lat}{Latitude of your current location.}
+
+\item{lon}{Longitude of your current location.}
 }
 \description{
 These functions help manage switching between preferred themes. Use
@@ -90,6 +100,8 @@ declare your default themes:\preformatted{if (interactive() && requireNamespace(
   setHook("rstudio.sessionInit", function(isNewSession) \{
     # Automatically choose the correct theme based on time of day
     rsthemes::use_theme_auto(dark_start = "18:00", dark_end = "6:00")
+    # Alternatively use a dynamic solution based on your location
+    # rsthemes::use_theme_auto(lat = 50.30, lon = 9.40)
   \}, action = "append")
 \}
 }

--- a/man/auto_theme.Rd
+++ b/man/auto_theme.Rd
@@ -113,10 +113,11 @@ declare your default themes:\preformatted{if (interactive() && requireNamespace(
 Note that the fully automated approach will use
 \href{https://ip-api.com/}{ip-api.com} to look up your current location using your
 IP address (if the \pkg{ipapi} package is available). If you'd like to use
-geolocation but without pining an external server, you can call
+geolocation but without pinging an external server, you can call
 \code{rsthemes:::geolocate()} once to determine your approximate latitude and
-longitude. Your location coordinates are cached on a per-project basis and
-checked once per day (per project).
+longitude, which you can provide to \code{\link[=use_theme_auto]{use_theme_auto()}}. Your location
+coordinates are cached on a per-project basis and only checked once per day
+(per project).
 
 Here are two other approaches that you can use. Both set the global
 options that declare the default themes, but rely on you manually calling


### PR DESCRIPTION
fixes #32 

I also made some opinionated changes to the defaults of `dark_start` and `dark_end` to be able to add args `lat` and `lon`. This might break backward comp for some users even though I do not think that many will use the current defaults in production.

There might be more robust ways to implement this and as you can see I did not add any checks or assertions but it does the job ;)

I also did a run of `styler::tidyverse_style()` - just cherry pick the other changes if you dislike the styling.