### PR TITLE
Notify users if suncalc is not installed

### DIFF
--- a/R/auto.R
+++ b/R/auto.R
@@ -267,6 +267,13 @@ use_theme_auto <- function(
 }
 
 local_daylight_hours <- function(lat = NULL, lon = NULL, quietly = FALSE) {
+
+  if (!requireNamespace("suncalc", quietly = TRUE)) {
+    cli::cli_alert_warning("{.fun rsthemes::use_theme_auto}: To use automatic
+      theme switching based on location, please install package
+      {.pkg suncalc}.", wrap = TRUE)
+  }
+
   coords <- list(lat = lat, lon = lon)
   null_times <- list(end = NULL, start = NULL)
   if (any(is_null(coords))) {

--- a/R/auto.R
+++ b/R/auto.R
@@ -267,24 +267,44 @@ use_theme_auto <- function(
 }
 
 local_daylight_hours <- function(lat = NULL, lon = NULL, quietly = FALSE) {
-
-  if (!requireNamespace("suncalc", quietly = TRUE)) {
-    cli::cli_alert_warning("{.fun rsthemes::use_theme_auto}: To use automatic
-      theme switching based on location, please install package
-      {.pkg suncalc}.", wrap = TRUE)
-  }
-
   coords <- list(lat = lat, lon = lon)
   null_times <- list(end = NULL, start = NULL)
+
+  has_suncalc <- requireNamespace("suncalc", quietly = TRUE)
+  has_ipapi   <- requireNamespace("ipapi", quietly = TRUE)
+
   if (any(is_null(coords))) {
+    if (!has_ipapi) {
+      cli::cli_alert_warning(
+        "[rsthemes] {.fun use_theme_auto} requires {.pkg ipapi} to determine
+        your location. Suppress this warning by providing {.arg lat} and
+        {.arg lon} or by installing {.pkg api}:
+        {.code devtools::install_github(\"hrbrmstr/ipapi\")}
+        ",
+        wrap = TRUE
+      )
+      return(null_times)
+    }
     coords <- purrr::possibly(geolocate, null_times)(quietly = quietly)
   }
+
   if (all(is_null(coords))) {
     return(null_times)
   }
-  if (!requireNamespace("suncalc", quietly = TRUE)) {
-    stop("`suncalc` is required: install.packages('suncalc')")
+
+  if (!has_suncalc) {
+    cli::cli_alert_warning(
+      "[rsthemes] {.fun use_theme_auto} requires {.pkg suncalc} to determine
+      your sunrise/sunset times in your location. Suppress this warning by
+      providing explicit {.arg dark_start} and {.arg dark_end} times or by
+      installing {.pkg suncalc}:
+      {.code install.packages(\"suncalc\")}
+      ",
+      wrap = TRUE
+    )
+    return(null_times)
   }
+
   times <- suncalc::getSunlightTimes(
     lat = coords$lat,
     lon = coords$lon,


### PR DESCRIPTION
Due to {suncalc} being in Suggests, it is currently silently ignored if missing and hence location based functionality will not work if.

This just happened to me on a new machine. This might cause headaches to users since nothing is happening but also no error is thrown.

I added a small message to tell the user what to do.