### PR TITLE
Replace opacity with rgba in themes

### DIFF
--- a/inst/themes/a11y-dark.rstheme
+++ b/inst/themes/a11y-dark.rstheme
@@ -45,7 +45,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: rgba(0, 224, 224, 0.5);
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {

--- a/inst/themes/a11y-light.rstheme
+++ b/inst/themes/a11y-light.rstheme
@@ -54,7 +54,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: rgba(217, 30, 24, 0.5);
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {

--- a/inst/themes/fairyfloss.rstheme
+++ b/inst/themes/fairyfloss.rstheme
@@ -48,8 +48,7 @@
 
 .normal-mode .ace_cursor {
   border: 0 !important;
-  background-color: #c2ffdf;
-  opacity: 0.5;
+  background-color: rgba(194, 255, 223, 0.5);
 }
 
 .ace_marker-layer .ace_selection {

--- a/inst/themes/flat-white.rstheme
+++ b/inst/themes/flat-white.rstheme
@@ -59,8 +59,7 @@
 
 .normal-mode .ace_cursor {
   border: 0 !important;
-  background-color: #6a4dff;
-  opacity: 0.5;
+  background-color: rgba(106, 77, 255, 0.5);
 }
 
 .ace_marker-layer .ace_selection {

--- a/inst/themes/github.rstheme
+++ b/inst/themes/github.rstheme
@@ -54,8 +54,7 @@
 
 .normal-mode .ace_cursor {
   border: 0 !important;
-  background-color: #d73a49;
-  opacity: 0.5;
+  background-color: rgba(215, 58, 73, 0.5);
 }
 
 .ace_marker-layer .ace_selection {

--- a/inst/themes/horizon-dark.rstheme
+++ b/inst/themes/horizon-dark.rstheme
@@ -44,8 +44,7 @@
 
 .normal-mode .ace_cursor {
   border: 0 !important;
-  background-color: #1eaeae;
-  opacity: 0.5;
+  background-color: rgba(30, 174, 174, 0.5);
 }
 
 .ace_marker-layer .ace_selection {

--- a/inst/themes/night-owl.rstheme
+++ b/inst/themes/night-owl.rstheme
@@ -45,7 +45,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: rgba(92, 167, 228, 0.5);
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {

--- a/inst/themes/nord-polar-night-aurora.rstheme
+++ b/inst/themes/nord-polar-night-aurora.rstheme
@@ -44,8 +44,7 @@
 
 .normal-mode .ace_cursor {
   border: 0 !important;
-  background-color: #81a1c1;
-  opacity: 0.5;
+  background-color: rgba(129, 161, 193, 0.5);
 }
 
 .ace_marker-layer .ace_selection {

--- a/inst/themes/nord-snow-storm.rstheme
+++ b/inst/themes/nord-snow-storm.rstheme
@@ -53,8 +53,7 @@
 
 .normal-mode .ace_cursor {
   border: 0 !important;
-  background-color: #d08770;
-  opacity: 0.5;
+  background-color: rgba(208, 135, 112, 0.5);
 }
 
 .ace_marker-layer .ace_selection {

--- a/inst/themes/oceanic-plus.rstheme
+++ b/inst/themes/oceanic-plus.rstheme
@@ -45,8 +45,7 @@
 
 .normal-mode .ace_cursor {
   border: 0 !important;
-  background-color: #FAC863;
-  opacity: 0.5;
+  background-color: rgba(250, 200, 99, 0.5);
 }
 
 .ace_marker-layer .ace_selection {

--- a/inst/themes/one-dark.rstheme
+++ b/inst/themes/one-dark.rstheme
@@ -44,8 +44,7 @@
 
 .normal-mode .ace_cursor {
   border: 0 !important;
-  background-color: #528bff;
-  opacity: 0.5;
+  background-color: rgba(82, 139, 255, 0.5);
 }
 
 .ace_marker-layer .ace_selection {

--- a/inst/themes/one-light.rstheme
+++ b/inst/themes/one-light.rstheme
@@ -53,8 +53,7 @@
 
 .normal-mode .ace_cursor {
   border: 0 !important;
-  background-color: #526fff;
-  opacity: 0.5;
+  background-color: rgba(82, 111, 255, 0.5);
 }
 
 .ace_marker-layer .ace_selection {

--- a/inst/themes/solarized-dark.rstheme
+++ b/inst/themes/solarized-dark.rstheme
@@ -49,8 +49,7 @@
 
 .normal-mode .ace_cursor {
   border: 0 !important;
-  background-color: #dc322f;
-  opacity: 0.5;
+  background-color: rgba(220, 50, 47, 0.5);
 }
 
 .ace_marker-layer .ace_selection {

--- a/inst/themes/solarized-light.rstheme
+++ b/inst/themes/solarized-light.rstheme
@@ -49,8 +49,7 @@
 
 .normal-mode .ace_cursor {
   border: 0 !important;
-  background-color: #dc322f;
-  opacity: 0.5;
+  background-color: rgba(220, 50, 47, 0.5);
 }
 
 .ace_marker-layer .ace_selection {

--- a/inst/themes/yule-rstudio-reduced-motion.rstheme
+++ b/inst/themes/yule-rstudio-reduced-motion.rstheme
@@ -45,7 +45,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: rgba(100, 243, 240, 0.6);
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {

--- a/inst/themes/yule-rstudio-rsthemes.rstheme
+++ b/inst/themes/yule-rstudio-rsthemes.rstheme
@@ -45,7 +45,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: rgba(100, 243, 240, 0.6);
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {


### PR DESCRIPTION
I noticed for a couple of themes where using them with vim-mode was harder, because the cursor was just a big block with no transparency. It seems that the `opacity` value doesn't do anything, so  I replaced all hex-color values for the cursor in normal mode with `rgba` values. I defaulted to 0.5 opacity unless the theme already had another value.

I didn't do it for the base16 themes yet because they are so many I would probably write a script for that so I wanted to check with you first.