### PR TITLE
Ensure cursor appears behind text

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -42,7 +42,7 @@ render_sass <- function(
 
   outfile <- fs::path(outdir, outfile)
   if (input_is_text) {
-    sass::sass(file, output = outfile)
+    sass::sass(file, output = outfile, cache = NULL)
   } else {
     sass::sass(sass::sass_file(file), output = outfile, cache = NULL)
   }

--- a/inst/templates/rstudio/_rstudio-dark.scss
+++ b/inst/templates/rstudio/_rstudio-dark.scss
@@ -187,12 +187,15 @@ $ui_rstudio_is_dark: true;
   background-color: $ui_line_find;
 }
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
   &.ace_print-margin-layer {
     z-index: 2;
   }
   &.ace_marker-layer {
     z-index: 1;
+  }
+  &.ace_cursor-layer {
+    z-index: 3;
   }
 }
 .ace_selection.ace_start {

--- a/inst/templates/rstudio/_rstudio-dark.scss
+++ b/inst/templates/rstudio/_rstudio-dark.scss
@@ -39,7 +39,6 @@ $ui_rstudio_is_dark: true;
 .normal-mode .ace_cursor {
   border: 0!important;
   background-color: $ui_cursor_normal_mode;
-  opacity: 0.5;
 }
 .ace_marker-layer {
   .ace_selection {

--- a/inst/templates/rstudio/_rstudio-light.scss
+++ b/inst/templates/rstudio/_rstudio-light.scss
@@ -46,7 +46,6 @@ $ui_rstudio_is_dark: false;
 .normal-mode .ace_cursor {
   border: 0!important;
   background-color: $ui_cursor_normal_mode;
-  opacity: 0.5;
 }
 .ace_marker-layer {
   .ace_selection {

--- a/inst/templates/rstudio/_rstudio-light.scss
+++ b/inst/templates/rstudio/_rstudio-light.scss
@@ -217,12 +217,15 @@ $ui_rstudio_is_dark: false;
   background-color: $ui_line_find;
 }
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
   &.ace_print-margin-layer {
     z-index: 2;
   }
   &.ace_marker-layer {
     z-index: 1;
+  }
+  &.ace_cursor-layer {
+    z-index: 3;
   }
 }
 .ace_selection.ace_start {

--- a/inst/themes/a11y-dark.rstheme
+++ b/inst/themes/a11y-dark.rstheme
@@ -45,7 +45,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: rgba(0, 224, 224, 0.5);
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -221,7 +220,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -230,6 +229,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {

--- a/inst/themes/a11y-light.rstheme
+++ b/inst/themes/a11y-light.rstheme
@@ -54,7 +54,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: rgba(217, 30, 24, 0.5);
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -255,7 +254,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -264,6 +263,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {

--- a/inst/themes/base16/base16-3024.rstheme
+++ b/inst/themes/base16/base16-3024.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #fded02;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #3a3432 #090300;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-apathy.rstheme
+++ b/inst/themes/base16/base16-apathy.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #3E4C96;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #0B342D #031A16;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-ashes.rstheme
+++ b/inst/themes/base16/base16-ashes.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #AEC795;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #393F45 #1C2023;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-atelier-cave.rstheme
+++ b/inst/themes/base16/base16-atelier-cave.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #a06e3b;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #26232a #19171c;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-atelier-dune.rstheme
+++ b/inst/themes/base16/base16-atelier-dune.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #ae9513;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #292824 #20201d;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-atelier-estuary.rstheme
+++ b/inst/themes/base16/base16-atelier-estuary.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #a5980d;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #302f27 #22221b;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-atelier-forest.rstheme
+++ b/inst/themes/base16/base16-atelier-forest.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #c38418;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #2c2421 #1b1918;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-atelier-heath.rstheme
+++ b/inst/themes/base16/base16-atelier-heath.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #bb8a35;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #292329 #1b181b;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-atelier-lakeside.rstheme
+++ b/inst/themes/base16/base16-atelier-lakeside.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #8a8a0f;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #1f292e #161b1d;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-atelier-plateau.rstheme
+++ b/inst/themes/base16/base16-atelier-plateau.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #a06e3b;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #292424 #1b1818;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-atelier-savanna.rstheme
+++ b/inst/themes/base16/base16-atelier-savanna.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #a07e3b;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #232a25 #171c19;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-atelier-seaside.rstheme
+++ b/inst/themes/base16/base16-atelier-seaside.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #98981b;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #242924 #131513;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-atelier-sulphurpool.rstheme
+++ b/inst/themes/base16/base16-atelier-sulphurpool.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #c08b30;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #293256 #202746;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-bespin.rstheme
+++ b/inst/themes/base16/base16-bespin.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #f9ee98;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #36312e #28211c;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-brewer.rstheme
+++ b/inst/themes/base16/base16-brewer.rstheme
@@ -47,7 +47,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #dca060;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -223,7 +222,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -232,6 +231,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -439,13 +442,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #2e2f30 #0c0d0e;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-bright.rstheme
+++ b/inst/themes/base16/base16-bright.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #fda331;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #303030 #000000;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-chalk.rstheme
+++ b/inst/themes/base16/base16-chalk.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #ddb26f;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #202020 #151515;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-codeschool.rstheme
+++ b/inst/themes/base16/base16-codeschool.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #a03b1e;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #1c3657 #232c31;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-cupcake.rstheme
+++ b/inst/themes/base16/base16-cupcake.rstheme
@@ -55,7 +55,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #DCB16C;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -256,7 +255,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -265,6 +264,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -469,13 +472,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #f2f1f4 #fbf1f2;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-darktooth.rstheme
+++ b/inst/themes/base16/base16-darktooth.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #FAC03B;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #32302F #1D2021;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-default-dark.rstheme
+++ b/inst/themes/base16/base16-default-dark.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #f7ca88;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #282828 #181818;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-default-light.rstheme
+++ b/inst/themes/base16/base16-default-light.rstheme
@@ -55,7 +55,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #f7ca88;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -256,7 +255,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -265,6 +264,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -469,13 +472,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #e8e8e8 #f8f8f8;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-dracula.rstheme
+++ b/inst/themes/base16/base16-dracula.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #00f769;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #3a3c4e #282936;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-eighties.rstheme
+++ b/inst/themes/base16/base16-eighties.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #ffcc66;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #393939 #2d2d2d;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-embers.rstheme
+++ b/inst/themes/base16/base16-embers.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #6D8257;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #2C2620 #16130F;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-flat.rstheme
+++ b/inst/themes/base16/base16-flat.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #F1C40F;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #34495E #2C3E50;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-google-dark.rstheme
+++ b/inst/themes/base16/base16-google-dark.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #FBA922;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #282a2e #1d1f21;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-google-light.rstheme
+++ b/inst/themes/base16/base16-google-light.rstheme
@@ -55,7 +55,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #FBA922;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -256,7 +255,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -265,6 +264,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -469,13 +472,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #e0e0e0 #ffffff;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-grayscale-dark.rstheme
+++ b/inst/themes/base16/base16-grayscale-dark.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #a0a0a0;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #252525 #101010;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-grayscale-light.rstheme
+++ b/inst/themes/base16/base16-grayscale-light.rstheme
@@ -55,7 +55,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #a0a0a0;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -256,7 +255,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -265,6 +264,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -469,13 +472,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #e3e3e3 #f7f7f7;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-green-screen.rstheme
+++ b/inst/themes/base16/base16-green-screen.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #007700;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #003300 #001100;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-gruvbox-dark-hard.rstheme
+++ b/inst/themes/base16/base16-gruvbox-dark-hard.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #fabd2f;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #3c3836 #1d2021;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-gruvbox-dark-medium.rstheme
+++ b/inst/themes/base16/base16-gruvbox-dark-medium.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #fabd2f;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #3c3836 #282828;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-gruvbox-dark-pale.rstheme
+++ b/inst/themes/base16/base16-gruvbox-dark-pale.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #ffaf00;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #3a3a3a #262626;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-gruvbox-dark-soft.rstheme
+++ b/inst/themes/base16/base16-gruvbox-dark-soft.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #fabd2f;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #3c3836 #32302f;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-gruvbox-light-hard.rstheme
+++ b/inst/themes/base16/base16-gruvbox-light-hard.rstheme
@@ -55,7 +55,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #b57614;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -256,7 +255,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -265,6 +264,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -469,13 +472,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #ebdbb2 #f9f5d7;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-gruvbox-light-medium.rstheme
+++ b/inst/themes/base16/base16-gruvbox-light-medium.rstheme
@@ -55,7 +55,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #b57614;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -256,7 +255,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -265,6 +264,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -469,13 +472,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #ebdbb2 #fbf1c7;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-gruvbox-light-soft.rstheme
+++ b/inst/themes/base16/base16-gruvbox-light-soft.rstheme
@@ -55,7 +55,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #b57614;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -256,7 +255,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -265,6 +264,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -469,13 +472,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #ebdbb2 #f2e5bc;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-harmonic16-dark.rstheme
+++ b/inst/themes/base16/base16-harmonic16-dark.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #8bbf56;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #223b54 #0b1c2c;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-harmonic16-light.rstheme
+++ b/inst/themes/base16/base16-harmonic16-light.rstheme
@@ -55,7 +55,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #8bbf56;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -256,7 +255,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -265,6 +264,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -469,13 +472,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #e5ebf1 #f7f9fb;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-hopscotch.rstheme
+++ b/inst/themes/base16/base16-hopscotch.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #fdcc59;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #433b42 #322931;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-ir-black.rstheme
+++ b/inst/themes/base16/base16-ir-black.rstheme
@@ -47,7 +47,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #ffffb6;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -223,7 +222,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -232,6 +231,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -439,13 +442,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #242422 #000000;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-isotope.rstheme
+++ b/inst/themes/base16/base16-isotope.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #ff0099;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #404040 #000000;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-london-tube.rstheme
+++ b/inst/themes/base16/base16-london-tube.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #ffd204;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #1c3f95 #231f20;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-macintosh.rstheme
+++ b/inst/themes/base16/base16-macintosh.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #fbf305;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #404040 #000000;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-marrakesh.rstheme
+++ b/inst/themes/base16/base16-marrakesh.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #a88339;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #302e00 #201602;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-materia.rstheme
+++ b/inst/themes/base16/base16-materia.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #FFCC00;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #2C393F #263238;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-mexico-light.rstheme
+++ b/inst/themes/base16/base16-mexico-light.rstheme
@@ -55,7 +55,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #f79a0e;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -256,7 +255,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -265,6 +264,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -469,13 +472,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #e8e8e8 #f8f8f8;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-mocha.rstheme
+++ b/inst/themes/base16/base16-mocha.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #f4bc87;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #534636 #3B3228;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-monokai.rstheme
+++ b/inst/themes/base16/base16-monokai.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #f4bf75;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #383830 #272822;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-nord.rstheme
+++ b/inst/themes/base16/base16-nord.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #5E81AC;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #3B4252 #2E3440;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-ocean.rstheme
+++ b/inst/themes/base16/base16-ocean.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #ebcb8b;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #343d46 #2b303b;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-oceanicnext.rstheme
+++ b/inst/themes/base16/base16-oceanicnext.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #FAC863;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #343D46 #1B2B34;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-onedark.rstheme
+++ b/inst/themes/base16/base16-onedark.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #e5c07b;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #353b45 #282c34;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-paraiso.rstheme
+++ b/inst/themes/base16/base16-paraiso.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #fec418;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #41323f #2f1e2e;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-phd.rstheme
+++ b/inst/themes/base16/base16-phd.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #fbd461;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #2a3448 #061229;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-pico.rstheme
+++ b/inst/themes/base16/base16-pico.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #fff024;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #1d2b53 #000000;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-pop.rstheme
+++ b/inst/themes/base16/base16-pop.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #f8ca12;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #202020 #000000;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-railscasts.rstheme
+++ b/inst/themes/base16/base16-railscasts.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #ffc66d;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #272935 #2b2b2b;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-rebecca.rstheme
+++ b/inst/themes/base16/base16-rebecca.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #ae81ff;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #663399 #292a44;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-seti-ui.rstheme
+++ b/inst/themes/base16/base16-seti-ui.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #e6cd69;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #8ec43d #151718;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-shapeshifter.rstheme
+++ b/inst/themes/base16/base16-shapeshifter.rstheme
@@ -55,7 +55,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #dddd13;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -256,7 +255,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -265,6 +264,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -469,13 +472,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #e0e0e0 #f9f9f9;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-solar-flare.rstheme
+++ b/inst/themes/base16/base16-solar-flare.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #E4B51C;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #222E38 #18262F;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-solarized-dark.rstheme
+++ b/inst/themes/base16/base16-solarized-dark.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #b58900;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #073642 #002b36;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-solarized-light.rstheme
+++ b/inst/themes/base16/base16-solarized-light.rstheme
@@ -55,7 +55,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #b58900;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -256,7 +255,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -265,6 +264,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -469,13 +472,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #eee8d5 #fdf6e3;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-spacemacs.rstheme
+++ b/inst/themes/base16/base16-spacemacs.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #b1951d;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #282828 #1f2022;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-summerfruit-dark.rstheme
+++ b/inst/themes/base16/base16-summerfruit-dark.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #ABA800;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #202020 #151515;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-summerfruit-light.rstheme
+++ b/inst/themes/base16/base16-summerfruit-light.rstheme
@@ -55,7 +55,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #ABA800;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -256,7 +255,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -265,6 +264,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -469,13 +472,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #E0E0E0 #FFFFFF;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-tomorrow-night.rstheme
+++ b/inst/themes/base16/base16-tomorrow-night.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #f0c674;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #282a2e #1d1f21;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-tomorrow.rstheme
+++ b/inst/themes/base16/base16-tomorrow.rstheme
@@ -55,7 +55,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #eab700;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -256,7 +255,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -265,6 +264,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -469,13 +472,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #e0e0e0 #ffffff;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-twilight.rstheme
+++ b/inst/themes/base16/base16-twilight.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #f9ee98;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #323537 #1e1e1e;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-unikitty-dark.rstheme
+++ b/inst/themes/base16/base16-unikitty-dark.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #dc8a0e;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #4a464d #2e2a31;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-unikitty-light.rstheme
+++ b/inst/themes/base16/base16-unikitty-light.rstheme
@@ -55,7 +55,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #dc8a0e;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -256,7 +255,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -265,6 +264,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -469,13 +472,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #e1e1e2 #ffffff;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/base16/base16-woodland.rstheme
+++ b/inst/themes/base16/base16-woodland.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #e0ac16;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {
@@ -438,13 +441,13 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 /* scrollbars */
 .rstudio-themes-flat {
   /* Works on Firefox */
-  scrollbar-width: 12px;
+  scrollbar-width: auto;
   scrollbar-color: #302b25 #231e18;
   /* Works on Chrome, Edge, and Safari */
 }
 
 .rstudio-themes-flat ::-webkit-scrollbar {
-  width: 12px;
+  width: auto;
 }
 
 .rstudio-themes-flat *::-webkit-scrollbar-track {

--- a/inst/themes/fairyfloss.rstheme
+++ b/inst/themes/fairyfloss.rstheme
@@ -49,7 +49,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #c2ffdf;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -225,7 +224,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -234,6 +233,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {

--- a/inst/themes/flat-white.rstheme
+++ b/inst/themes/flat-white.rstheme
@@ -60,7 +60,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #6a4dff;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -261,7 +260,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -270,6 +269,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {

--- a/inst/themes/github.rstheme
+++ b/inst/themes/github.rstheme
@@ -55,7 +55,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #d73a49;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -256,7 +255,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -265,6 +264,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {

--- a/inst/themes/horizon-dark.rstheme
+++ b/inst/themes/horizon-dark.rstheme
@@ -45,7 +45,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #1eaeae;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -221,7 +220,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -230,6 +229,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {

--- a/inst/themes/night-owl.rstheme
+++ b/inst/themes/night-owl.rstheme
@@ -45,7 +45,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: rgba(92, 167, 228, 0.5);
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -221,7 +220,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -230,6 +229,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {

--- a/inst/themes/nord-polar-night-aurora.rstheme
+++ b/inst/themes/nord-polar-night-aurora.rstheme
@@ -45,7 +45,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #81a1c1;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -221,7 +220,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -230,6 +229,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {

--- a/inst/themes/nord-snow-storm.rstheme
+++ b/inst/themes/nord-snow-storm.rstheme
@@ -54,7 +54,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #d08770;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -255,7 +254,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -264,6 +263,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {

--- a/inst/themes/oceanic-plus.rstheme
+++ b/inst/themes/oceanic-plus.rstheme
@@ -46,7 +46,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #FAC863;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -222,7 +221,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -231,6 +230,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {

--- a/inst/themes/one-dark.rstheme
+++ b/inst/themes/one-dark.rstheme
@@ -45,7 +45,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #528bff;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -221,7 +220,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -230,6 +229,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {

--- a/inst/themes/one-light.rstheme
+++ b/inst/themes/one-light.rstheme
@@ -54,7 +54,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #526fff;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -255,7 +254,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -264,6 +263,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {

--- a/inst/themes/solarized-dark.rstheme
+++ b/inst/themes/solarized-dark.rstheme
@@ -50,7 +50,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #dc322f;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -226,7 +225,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -235,6 +234,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {

--- a/inst/themes/solarized-light.rstheme
+++ b/inst/themes/solarized-light.rstheme
@@ -50,7 +50,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: #dc322f;
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -226,7 +225,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -235,6 +234,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {

--- a/inst/themes/yule-rstudio-reduced-motion.rstheme
+++ b/inst/themes/yule-rstudio-reduced-motion.rstheme
@@ -45,7 +45,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: rgba(100, 243, 240, 0.6);
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -221,7 +220,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -230,6 +229,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {

--- a/inst/themes/yule-rstudio-rsthemes.rstheme
+++ b/inst/themes/yule-rstudio-rsthemes.rstheme
@@ -45,7 +45,6 @@
 .normal-mode .ace_cursor {
   border: 0 !important;
   background-color: rgba(100, 243, 240, 0.6);
-  opacity: 0.5;
 }
 
 .ace_marker-layer .ace_selection {
@@ -221,7 +220,7 @@
 }
 
 .ace_layer {
-  z-index: 3;
+  z-index: 4;
 }
 
 .ace_layer.ace_print-margin-layer {
@@ -230,6 +229,10 @@
 
 .ace_layer.ace_marker-layer {
   z-index: 1;
+}
+
+.ace_layer.ace_cursor-layer {
+  z-index: 3;
 }
 
 .ace_selection.ace_start {


### PR DESCRIPTION
An alternative fix for the issue pointed out in #52 by @jmbuhr where the normal mode cursor appears on top of the text layer and hides the text beneath it. Rather than making the cursor transparent, this PR moves the cursor layer below the text layer.

I removed the `opacity: 0.5` property from `.normal_mode .ace_cursor` since this property is overwritten by the blinking animation.

We could still adjust the transparency by setting `$ui_cursor_normal_mode` to a semi-transparent color (`ui_cursor_normal_mode` argument in `rstheme()`). But I personally prefer the stronger cursor color.

