### PR TITLE
RStudio 2022.01

### DIFF
--- a/inst/templates/a11y-dark.R
+++ b/inst/templates/a11y-dark.R
@@ -67,16 +67,16 @@ x <- rstheme(
 .ace_function {
   font-weight: 600;
 }
-.rstudio-themes-flat .rstudio-themes-border,
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe>div:last-child,
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_minimizedWindowObject,
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_minimizedWindowObject>div:last-child,
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_minimizedWindowObject table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_minimizedWindowObject table.rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_toolbarWrapper,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanel>div>div.gwt-TabLayoutPanelTabs {
+.rstudio-themes-dark-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe>div:last-child,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstudio-themes-background,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_minimizedWindowObject,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_minimizedWindowObject>div:last-child,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_minimizedWindowObject table.rstheme_tabLayoutCenter,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_minimizedWindowObject table.rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_toolbarWrapper,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanel>div>div.gwt-TabLayoutPanelTabs {
   border-color: #454545;
 }
 '

--- a/inst/templates/a11y-dark.R
+++ b/inst/templates/a11y-dark.R
@@ -67,16 +67,16 @@ x <- rstheme(
 .ace_function {
   font-weight: 600;
 }
-.rstudio-themes-dark-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe>div:last-child,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstudio-themes-background,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_minimizedWindowObject,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_minimizedWindowObject>div:last-child,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_minimizedWindowObject table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_minimizedWindowObject table.rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_toolbarWrapper,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanel>div>div.gwt-TabLayoutPanelTabs {
+body .rstudio-themes-border,
+body .rstudio-themes-dark-grey .windowframe>div:last-child,
+body .rstudio-themes-dark-grey .rstudio-themes-background,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+body .rstudio-themes-dark-grey .rstheme_minimizedWindowObject,
+body .rstudio-themes-dark-grey .rstheme_minimizedWindowObject>div:last-child,
+body .rstudio-themes-dark-grey .rstheme_minimizedWindowObject table.rstheme_tabLayoutCenter,
+body .rstudio-themes-dark-grey .rstheme_minimizedWindowObject table.rstheme_center,
+body .rstudio-themes-dark-grey .rstheme_toolbarWrapper,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanel>div>div.gwt-TabLayoutPanelTabs {
   border-color: #454545;
 }
 '

--- a/inst/templates/a11y-dark.scss
+++ b/inst/templates/a11y-dark.scss
@@ -95,16 +95,16 @@ $rmd_href_background: $code_reserved_background;
 .ace_function {
   font-weight: 600;
 }
-.rstudio-themes-dark-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe>div:last-child,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstudio-themes-background,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_minimizedWindowObject,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_minimizedWindowObject>div:last-child,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_minimizedWindowObject table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_minimizedWindowObject table.rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_toolbarWrapper,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanel>div>div.gwt-TabLayoutPanelTabs {
+body .rstudio-themes-border,
+body .rstudio-themes-dark-grey .windowframe>div:last-child,
+body .rstudio-themes-dark-grey .rstudio-themes-background,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+body .rstudio-themes-dark-grey .rstheme_minimizedWindowObject,
+body .rstudio-themes-dark-grey .rstheme_minimizedWindowObject>div:last-child,
+body .rstudio-themes-dark-grey .rstheme_minimizedWindowObject table.rstheme_tabLayoutCenter,
+body .rstudio-themes-dark-grey .rstheme_minimizedWindowObject table.rstheme_center,
+body .rstudio-themes-dark-grey .rstheme_toolbarWrapper,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanel>div>div.gwt-TabLayoutPanelTabs {
   border-color: #454545;
 }
 

--- a/inst/templates/a11y-dark.scss
+++ b/inst/templates/a11y-dark.scss
@@ -95,16 +95,16 @@ $rmd_href_background: $code_reserved_background;
 .ace_function {
   font-weight: 600;
 }
-.rstudio-themes-flat .rstudio-themes-border,
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe>div:last-child,
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_minimizedWindowObject,
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_minimizedWindowObject>div:last-child,
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_minimizedWindowObject table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_minimizedWindowObject table.rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_toolbarWrapper,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanel>div>div.gwt-TabLayoutPanelTabs {
+.rstudio-themes-dark-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe>div:last-child,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstudio-themes-background,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_minimizedWindowObject,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_minimizedWindowObject>div:last-child,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_minimizedWindowObject table.rstheme_tabLayoutCenter,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_minimizedWindowObject table.rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_toolbarWrapper,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanel>div>div.gwt-TabLayoutPanelTabs {
   border-color: #454545;
 }
 

--- a/inst/templates/flat-white.scss
+++ b/inst/templates/flat-white.scss
@@ -149,42 +149,42 @@ $ui_rstudio_dialog_button_hover_foreground: $ui_rstudio_foreground;
     background-color: $base4;
   }
 }
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border,
-.rstudio-themes-light-menus .windowframe>div:last-child,
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_toolbarWrapper,
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_secondaryToolbar,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanel>div>div.gwt-TabLayoutPanelTabs {
+body .rstudio-themes-default .rstudio-themes-border,
+body .windowframe>div:last-child,
+body .rstudio-themes-default .rstheme_toolbarWrapper,
+body .rstudio-themes-default .rstheme_secondaryToolbar,
+body .rstudio-themes-default .gwt-TabLayoutPanel>div>div.gwt-TabLayoutPanelTabs {
   border-color: $base5 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_toolbarWrapper {
+body .rstudio-themes-default .rstheme_toolbarWrapper {
 }
 
 /* splitters */
-.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
+body > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
   border-color: transparent;
 }
 
-.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   border-color: transparent;
 }
 
-.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel td {
+body > .rstudio-themes-default .gwt-SplitLayoutPanel td {
   border-color: transparent;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanel>div>div.gwt-TabLayoutPanelTabs {
+body .rstudio-themes-default .gwt-TabLayoutPanel>div>div.gwt-TabLayoutPanelTabs {
   border-color: $base4;
 }
 
-.rstudio-themes-light-menus .rstheme_tabLayoutCenter,
-.rstudio-themes-light-menus .rstheme_tabLayoutCenter {
+body .rstheme_tabLayoutCenter,
+body .rstheme_tabLayoutCenter {
   border-color: $base5 !important;
   margin-left: 1px;
   margin-top: 1px;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTab-selected .rstheme_tabLayoutCenter {
+body .gwt-TabLayoutPanelTab-selected .rstheme_tabLayoutCenter {
   box-shadow: 2px 0 0 $ui-rstudio-tabs-active-border-left inset;
   border-radius: 0 !important;
   border-top: solid 1px $base4 !important;
@@ -193,11 +193,11 @@ $ui_rstudio_dialog_button_hover_foreground: $ui_rstudio_foreground;
   margin-left: 0!important;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTab:not(.gwt-TabLayoutPanelTab-selected) .rstheme_tabLayoutCenter {
+body .gwt-TabLayoutPanelTab:not(.gwt-TabLayoutPanelTab-selected) .rstheme_tabLayoutCenter {
   border-bottom: solid 2px $base4 !important;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanel > div:last-child {
+body .gwt-TabLayoutPanel > div:last-child {
   border-left: solid 1px $base4 !important;
   border-right: solid 1px $base4 !important;
 }

--- a/inst/templates/flat-white.scss
+++ b/inst/templates/flat-white.scss
@@ -149,42 +149,42 @@ $ui_rstudio_dialog_button_hover_foreground: $ui_rstudio_foreground;
     background-color: $base4;
   }
 }
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-border,
-.rstudio-themes-flat .windowframe>div:last-child,
-.rstudio-themes-flat .rstudio-themes-default .rstheme_toolbarWrapper,
-.rstudio-themes-flat .rstudio-themes-default .rstheme_secondaryToolbar,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanel>div>div.gwt-TabLayoutPanelTabs {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border,
+.rstudio-themes-light-menus .windowframe>div:last-child,
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_toolbarWrapper,
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_secondaryToolbar,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanel>div>div.gwt-TabLayoutPanelTabs {
   border-color: $base5 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstheme_toolbarWrapper {
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_toolbarWrapper {
 }
 
 /* splitters */
-.rstudio-themes-flat > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
+.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
   border-color: transparent;
 }
 
-.rstudio-themes-flat > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   border-color: transparent;
 }
 
-.rstudio-themes-flat > .rstudio-themes-default .gwt-SplitLayoutPanel td {
+.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel td {
   border-color: transparent;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanel>div>div.gwt-TabLayoutPanelTabs {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanel>div>div.gwt-TabLayoutPanelTabs {
   border-color: $base4;
 }
 
-.rstudio-themes-flat .rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstheme_tabLayoutCenter,
+.rstudio-themes-light-menus .rstheme_tabLayoutCenter {
   border-color: $base5 !important;
   margin-left: 1px;
   margin-top: 1px;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTab-selected .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTab-selected .rstheme_tabLayoutCenter {
   box-shadow: 2px 0 0 $ui-rstudio-tabs-active-border-left inset;
   border-radius: 0 !important;
   border-top: solid 1px $base4 !important;
@@ -193,11 +193,11 @@ $ui_rstudio_dialog_button_hover_foreground: $ui_rstudio_foreground;
   margin-left: 0!important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTab:not(.gwt-TabLayoutPanelTab-selected) .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTab:not(.gwt-TabLayoutPanelTab-selected) .rstheme_tabLayoutCenter {
   border-bottom: solid 2px $base4 !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanel > div:last-child {
+.rstudio-themes-light-menus .gwt-TabLayoutPanel > div:last-child {
   border-left: solid 1px $base4 !important;
   border-right: solid 1px $base4 !important;
 }

--- a/inst/templates/horizon-dark.R
+++ b/inst/templates/horizon-dark.R
@@ -74,7 +74,7 @@ rstheme(
     magenta = "$purple",
     blue = "#0F6DD2"
   ),
-  '.rstudio-themes-flat .gwt-TabLayoutPanelTab-selected {
+  '.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected {
     .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
       box-shadow: 0 3px 0 $red inset;
       border-radius: 0 !important;

--- a/inst/templates/horizon-dark.R
+++ b/inst/templates/horizon-dark.R
@@ -74,7 +74,7 @@ rstheme(
     magenta = "$purple",
     blue = "#0F6DD2"
   ),
-  '.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected {
+  'body .gwt-TabLayoutPanelTab-selected {
     .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
       box-shadow: 0 3px 0 $red inset;
       border-radius: 0 !important;

--- a/inst/templates/horizon-dark.scss
+++ b/inst/templates/horizon-dark.scss
@@ -105,7 +105,7 @@ $terminal_color_blue_bright: #0F6DD2;
 $terminal_color_magenta_bright: $purple;
 $terminal_color_cyan_bright: $teal;
 $terminal_color_white_bright: lighten($terminal_color_white, 10%);
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected {
+body .gwt-TabLayoutPanelTab-selected {
     .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
       box-shadow: 0 3px 0 $red inset;
       border-radius: 0 !important;

--- a/inst/templates/horizon-dark.scss
+++ b/inst/templates/horizon-dark.scss
@@ -105,7 +105,7 @@ $terminal_color_blue_bright: #0F6DD2;
 $terminal_color_magenta_bright: $purple;
 $terminal_color_cyan_bright: $teal;
 $terminal_color_white_bright: lighten($terminal_color_white, 10%);
-.rstudio-themes-flat .gwt-TabLayoutPanelTab-selected {
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected {
     .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
       box-shadow: 0 3px 0 $red inset;
       border-radius: 0 !important;

--- a/inst/templates/make.R
+++ b/inst/templates/make.R
@@ -5,7 +5,6 @@ r_files <- r_files[!grepl("make[.]R", r_files)]
 
 purrr::walk(r_files, source)
 
-withr::with_dir(here::here(), {
-  make_rsthemes()
-  install_rsthemes()
-})
+make_rsthemes(here::here("inst", "themes"), here::here("inst", "templates"))
+devtools::load_all()
+install_rsthemes()

--- a/inst/templates/material-darker.scss
+++ b/inst/templates/material-darker.scss
@@ -104,20 +104,17 @@ $terminal_color_blue_bright: #89DDFF;
 $terminal_color_magenta_bright: #C792EA;
 $terminal_color_cyan_bright: #80CBC4;
 $terminal_color_white_bright: lighten($terminal_color_white, 10%);
-.rstudio-themes-flat .gwt-TabLayoutPanelTab-selected {
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected {
     .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
       box-shadow: 0 -2px 0 $aqua inset;
       border-radius: 0 !important;
     }
-  }
-  
-/* remove border from panes */
-    .rstudio-themes-flat
-    :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
-    > div:last-child {
+    /* remove border from panes */
+    .rstudio-themes-dark-menus :-webkit-any(.windowframe, .rstheme_minimizedWindowObject) > div:last-child {
       border-color: $ui_rstudio_background !important;
     }
-    
+  }
+  
 @import "rstudio/_terminal.scss";
 $ui_command_palette_background: $ui_background;
 $ui_command_palette_search_background: $ui_command_palette_background;

--- a/inst/templates/material-lighter.scss
+++ b/inst/templates/material-lighter.scss
@@ -104,20 +104,17 @@ $terminal_color_blue_bright: #80CBC4;
 $terminal_color_magenta_bright: #7C4DFF;
 $terminal_color_cyan_bright: #39ADB5;
 $terminal_color_white_bright: lighten($terminal_color_white, 10%);
-.rstudio-themes-flat .gwt-TabLayoutPanelTab-selected {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTab-selected {
     .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
       box-shadow: 0 -2px 0 $sky inset;
       border-radius: 0 !important;
     }
-  }
-  
-/* remove border from panes */
-    .rstudio-themes-flat
-    :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
-    > div:last-child {
+    /* remove border from panes */
+    .rstudio-themes-light-menus :-webkit-any(.windowframe, .rstheme_minimizedWindowObject) > div:last-child {
       border-color: $ui_rstudio_background !important;
     }
-    
+  }
+  
 @import "rstudio/_terminal.scss";
 $ui_command_palette_background: $ui_background;
 $ui_command_palette_search_background: $ui_command_palette_background;

--- a/inst/templates/material-ocean.scss
+++ b/inst/templates/material-ocean.scss
@@ -104,20 +104,17 @@ $terminal_color_blue_bright: #89DDFF;
 $terminal_color_magenta_bright: #C792EA;
 $terminal_color_cyan_bright: #80CBC4;
 $terminal_color_white_bright: lighten($terminal_color_white, 10%);
-.rstudio-themes-flat .gwt-TabLayoutPanelTab-selected {
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected {
     .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
       box-shadow: 0 -2px 0 $aqua inset;
       border-radius: 0 !important;
     }
-  }
-  
-/* remove border from panes */
-    .rstudio-themes-flat
-    :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
-    > div:last-child {
+    /* remove border from panes */
+    .rstudio-themes-dark-menus :-webkit-any(.windowframe, .rstheme_minimizedWindowObject) > div:last-child {
       border-color: $ui_rstudio_background !important;
     }
-    
+  }
+  
 @import "rstudio/_terminal.scss";
 $ui_command_palette_background: $ui_background;
 $ui_command_palette_search_background: $ui_command_palette_background;

--- a/inst/templates/material-palenight.scss
+++ b/inst/templates/material-palenight.scss
@@ -104,20 +104,17 @@ $terminal_color_blue_bright: #89DDFF;
 $terminal_color_magenta_bright: #C792EA;
 $terminal_color_cyan_bright: #80CBC4;
 $terminal_color_white_bright: lighten($terminal_color_white, 10%);
-.rstudio-themes-flat .gwt-TabLayoutPanelTab-selected {
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected {
     .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
       box-shadow: 0 -2px 0 $purple inset;
       border-radius: 0 !important;
     }
-  }
-  
-/* remove border from panes */
-    .rstudio-themes-flat
-    :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
-    > div:last-child {
+    /* remove border from panes */
+    .rstudio-themes-dark-menus :-webkit-any(.windowframe, .rstheme_minimizedWindowObject) > div:last-child {
       border-color: $ui_rstudio_background !important;
     }
-    
+  }
+  
 @import "rstudio/_terminal.scss";
 $ui_command_palette_background: $ui_background;
 $ui_command_palette_search_background: $ui_command_palette_background;

--- a/inst/templates/material.R
+++ b/inst/templates/material.R
@@ -158,20 +158,21 @@ material_rstheme <- function(
       "$orange",
       "$teal"
     ),
-    sprintf(".rstudio-themes-flat .gwt-TabLayoutPanelTab-selected {
+    sprintf(".rstudio-themes-%s-menus .gwt-TabLayoutPanelTab-selected {
     .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
       box-shadow: 0 -2px 0 %s inset;
       border-radius: 0 !important;
     }
-  }
-  ", dialog_heading_foreground),
-    "/* remove border from panes */
-    .rstudio-themes-flat
-    :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
-    > div:last-child {
+    /* remove border from panes */
+    .rstudio-themes-%s-menus :-webkit-any(.windowframe, .rstheme_minimizedWindowObject) > div:last-child {
       border-color: $ui_rstudio_background !important;
     }
-    "
+  }
+  ",
+      if (is_dark) "dark" else "light",
+      dialog_heading_foreground,
+      if (is_dark) "dark" else "light"
+    )
   )
 
   theme_args <- modifyList(theme_args, list(...))

--- a/inst/templates/material.scss
+++ b/inst/templates/material.scss
@@ -104,20 +104,17 @@ $terminal_color_blue_bright: #89DDFF;
 $terminal_color_magenta_bright: #C792EA;
 $terminal_color_cyan_bright: #80CBC4;
 $terminal_color_white_bright: lighten($terminal_color_white, 10%);
-.rstudio-themes-flat .gwt-TabLayoutPanelTab-selected {
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected {
     .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
       box-shadow: 0 -2px 0 $teal inset;
       border-radius: 0 !important;
     }
-  }
-  
-/* remove border from panes */
-    .rstudio-themes-flat
-    :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
-    > div:last-child {
+    /* remove border from panes */
+    .rstudio-themes-dark-menus :-webkit-any(.windowframe, .rstheme_minimizedWindowObject) > div:last-child {
       border-color: $ui_rstudio_background !important;
     }
-    
+  }
+  
 @import "rstudio/_terminal.scss";
 $ui_command_palette_background: $ui_background;
 $ui_command_palette_search_background: $ui_command_palette_background;

--- a/inst/templates/night-owl.R
+++ b/inst/templates/night-owl.R
@@ -114,7 +114,7 @@ night_owl <- rstheme(
     yellow = "$orange-light",
     yellow_bright = "$yellow-light"
   ),
-  '.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected {
+  'body .gwt-TabLayoutPanelTab-selected {
     .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
       box-shadow: 0 4px 0 $blue2 inset;
       border-radius: 0 !important;

--- a/inst/templates/night-owl.R
+++ b/inst/templates/night-owl.R
@@ -114,7 +114,7 @@ night_owl <- rstheme(
     yellow = "$orange-light",
     yellow_bright = "$yellow-light"
   ),
-  '.rstudio-themes-flat .gwt-TabLayoutPanelTab-selected {
+  '.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected {
     .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
       box-shadow: 0 4px 0 $blue2 inset;
       border-radius: 0 !important;

--- a/inst/templates/night-owl.scss
+++ b/inst/templates/night-owl.scss
@@ -115,7 +115,7 @@ $terminal_color_blue_bright: $blue1;
 $terminal_color_magenta_bright: $purple;
 $terminal_color_cyan_bright: $teal-light;
 $terminal_color_white_bright: lighten($terminal_color_white, 10%);
-.rstudio-themes-flat .gwt-TabLayoutPanelTab-selected {
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected {
     .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
       box-shadow: 0 4px 0 $blue2 inset;
       border-radius: 0 !important;

--- a/inst/templates/night-owl.scss
+++ b/inst/templates/night-owl.scss
@@ -115,7 +115,7 @@ $terminal_color_blue_bright: $blue1;
 $terminal_color_magenta_bright: $purple;
 $terminal_color_cyan_bright: $teal-light;
 $terminal_color_white_bright: lighten($terminal_color_white, 10%);
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected {
+body .gwt-TabLayoutPanelTab-selected {
     .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
       box-shadow: 0 4px 0 $blue2 inset;
       border-radius: 0 !important;

--- a/inst/templates/one-dark.scss
+++ b/inst/templates/one-dark.scss
@@ -72,7 +72,7 @@ $ui_paren_6: $hue-2;
 @import "rstudio/_components";
 
 /* window containers */
-.rstudio-themes-flat
+.rstudio-themes-dark-menus
   > .rstudio-themes-dark
   :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
   > div:last-child {

--- a/inst/templates/one-dark.scss
+++ b/inst/templates/one-dark.scss
@@ -72,7 +72,7 @@ $ui_paren_6: $hue-2;
 @import "rstudio/_components";
 
 /* window containers */
-.rstudio-themes-dark-menus
+body
   > .rstudio-themes-dark
   :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
   > div:last-child {

--- a/inst/templates/rstudio/_command-palette.scss
+++ b/inst/templates/rstudio/_command-palette.scss
@@ -18,8 +18,8 @@ input#rstudio_command_palette_search {
   border-color: $ui_command_palette_search_background;
 }
 
-.rstudio-themes-light-menus,
-.rstudio-themes-dark-menus {
+body,
+body {
   .rstudio-themes-border {
     border-color: $ui_command_palette_border;
   }

--- a/inst/templates/rstudio/_command-palette.scss
+++ b/inst/templates/rstudio/_command-palette.scss
@@ -18,42 +18,45 @@ input#rstudio_command_palette_search {
   border-color: $ui_command_palette_search_background;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
-  border-color: $ui_command_palette_border;
-}
-
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] {
-  table .gwt-Label,
-  table td {
-    background-color: $ui_command_palette_item_background;
-    color: $ui_command_palette_item_color;
+.rstudio-themes-light-menus,
+.rstudio-themes-dark-menus {
+  .rstudio-themes-border {
+    border-color: $ui_command_palette_border;
   }
-  &:hover {
-    &, [id^="rstudio_command_entry"], table .gwt-Label, table td {
-      background-color: $ui_command_palette_item_hover_background;
+
+  .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] {
+    table .gwt-Label,
+    table td {
+      background-color: $ui_command_palette_item_background;
+      color: $ui_command_palette_item_color;
+    }
+    &:hover {
+      &, [id^="rstudio_command_entry"], table .gwt-Label, table td {
+        background-color: $ui_command_palette_item_hover_background;
+      }
     }
   }
-}
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] {
-  &, [id^="rstudio_command_entry"], table .gwt-Label, table td {
-    background-color: $ui_command_palette_item_selected_background;
+  .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] {
+    &, [id^="rstudio_command_entry"], table .gwt-Label, table td {
+      background-color: $ui_command_palette_item_selected_background;
+    }
   }
-}
 
-input#rstudio_command_palette_search {
-  padding: 10px 0;
-  width: 580px;
-  border: none;
-  .js-focus-visible & {
-    outline-offset: 5px !important;
-  }
-}
-
-// Fix labels colliding with other CSS rules for popups
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label {
-  &, & span {
+  input#rstudio_command_palette_search {
+    padding: 10px 0;
+    width: 580px;
     border: none;
+    .js-focus-visible & {
+      outline-offset: 5px !important;
+    }
+  }
+
+  // Fix labels colliding with other CSS rules for popups
+  .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label {
+    &, & span {
+      border: none;
+    }
   }
 }
 

--- a/inst/templates/rstudio/_dialog-options.scss
+++ b/inst/templates/rstudio/_dialog-options.scss
@@ -29,8 +29,8 @@ $ui_rstudio_dialog_checkbox_foreground: $ui_rstudio_dialog_foreground !default;
 $ui_rstudio_dialog_select_background: lighten($ui_rstudio_dialog_background, 5%) !default;
 $ui_rstudio_dialog_select_foreground: $ui_rstudio_dialog_foreground !default;
 
-.rstudio-themes-light-menus,
-.rstudio-themes-dark-menus {
+body,
+body {
   [id^="rstudio_dialog"],
   :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
   .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,

--- a/inst/templates/rstudio/_dialog-options.scss
+++ b/inst/templates/rstudio/_dialog-options.scss
@@ -29,7 +29,8 @@ $ui_rstudio_dialog_checkbox_foreground: $ui_rstudio_dialog_foreground !default;
 $ui_rstudio_dialog_select_background: lighten($ui_rstudio_dialog_background, 5%) !default;
 $ui_rstudio_dialog_select_foreground: $ui_rstudio_dialog_foreground !default;
 
-.rstudio-themes-flat {
+.rstudio-themes-light-menus,
+.rstudio-themes-dark-menus {
   [id^="rstudio_dialog"],
   :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
   .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,

--- a/inst/templates/rstudio/_large-tabs.scss
+++ b/inst/templates/rstudio/_large-tabs.scss
@@ -1,8 +1,8 @@
 $large-tabs-height: 40px !default;
 $large-tabs-width: 65px !default;
 
-.rstudio-themes-light-menus,
-.rstudio-themes-dark-menus {
+body,
+body {
   & > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel {
     & > div[aria-hidden="true"] + div {
       height: $large-tabs-height !important;

--- a/inst/templates/rstudio/_large-tabs.scss
+++ b/inst/templates/rstudio/_large-tabs.scss
@@ -1,50 +1,53 @@
 $large-tabs-height: 40px !default;
 $large-tabs-width: 65px !default;
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel {
-  & > div[aria-hidden="true"] + div {
-    height: $large-tabs-height !important;
-    background: $ui_rstudio_tabs_inactive_background;
+.rstudio-themes-light-menus,
+.rstudio-themes-dark-menus {
+  & > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel {
+    & > div[aria-hidden="true"] + div {
+      height: $large-tabs-height !important;
+      background: $ui_rstudio_tabs_inactive_background;
+    }
+    .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
+      padding-left: 20px;
+      padding-right: 20px;
+      height: $large-tabs-height;
+    }
+    .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
+      vertical-align: middle !important;
+    }
+    .gwt-TabLayoutPanelTabs > div:empty {
+      height: $large-tabs-height !important;
+    }
   }
-  .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
-    padding-left: 20px;
-    padding-right: 20px;
-    height: $large-tabs-height;
-  }
-  .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
-    vertical-align: middle !important;
-  }
-  .gwt-TabLayoutPanelTabs > div:empty {
-    height: $large-tabs-height !important;
-  }
-}
 
-.rstudio-themes-flat .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
-  border-color: $ui_rstudio_tabs_inactive_background !important;
-}
+  .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
+    border-color: $ui_rstudio_tabs_inactive_background !important;
+  }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs {
-  .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter {
-    tbody > tr > td:last-child > img {
-      display: none;
+  .gwt-TabLayoutPanelTabs {
+    .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter {
+      tbody > tr > td:last-child > img {
+        display: none;
+      }
+      &:hover tbody > tr > td:last-child > img {
+        display: inline-block;
+        position: absolute !important;
+        top: 0 !important;
+        padding-left: 3px;
+      }
     }
-    &:hover tbody > tr > td:last-child > img {
-      display: inline-block;
-      position: absolute !important;
-      top: 0 !important;
-      padding-left: 3px;
+    [id^="rstudio_workbench_"] {
+      .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+        padding-top: 5px;
+      }
     }
   }
-  [id^="rstudio_workbench_"] {
-    .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
-      padding-top: 5px;
-    }
+  .windowframe .gwt-TabLayoutPanel > div:last-child,
+  .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
+    top: 38px !important;
   }
-}
-.rstudio-themes-flat .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-flat .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
-  top: 38px !important;
-}
-.windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
-  height: $large-tabs-height!important;
+  .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
+    height: $large-tabs-height!important;
+  }
 }

--- a/inst/templates/rstudio/_rstudio-dark-flatter.scss
+++ b/inst/templates/rstudio/_rstudio-dark-flatter.scss
@@ -1,27 +1,27 @@
 // Flatter RStudio Dark
 
 /* borders on toolbar under editor */
-.rstudio-themes-dark-menus .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
+body .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
   border-color: $ui_rstudio_background !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 
 /* splitters */
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
   border-color: $ui_rstudio_background;
 }
 
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
   border-color: $ui_rstudio_background;
 }
 
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
   border-color: $ui_background !important;
 }
 
 /* window containers */
-.rstudio-themes-dark-menus
+body
   > .rstudio-themes-dark
   :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
   > div:last-child {

--- a/inst/templates/rstudio/_rstudio-dark-flatter.scss
+++ b/inst/templates/rstudio/_rstudio-dark-flatter.scss
@@ -1,27 +1,27 @@
 // Flatter RStudio Dark
 
 /* borders on toolbar under editor */
-.rstudio-themes-flat .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
+.rstudio-themes-dark-menus .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
   border-color: $ui_rstudio_background !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 
 /* splitters */
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
   border-color: $ui_rstudio_background;
 }
 
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
   border-color: $ui_rstudio_background;
 }
 
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
   border-color: $ui_background !important;
 }
 
 /* window containers */
-.rstudio-themes-flat
+.rstudio-themes-dark-menus
   > .rstudio-themes-dark
   :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
   > div:last-child {

--- a/inst/templates/rstudio/_rstudio-dark.scss
+++ b/inst/templates/rstudio/_rstudio-dark.scss
@@ -13,7 +13,7 @@ $ui_rstudio_is_dark: true;
   background-color: $ui_background;
   color: $ui_foreground;
 }
-.rstudio-themes-flat {
+.rstudio-themes-dark-menus {
   &.ace_editor_theme {
     background-color: $ui_background;
     color: $ui_foreground;
@@ -227,7 +227,7 @@ $ui_rstudio_is_dark: true;
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: $ui_rstudio_background !important;
   color: $ui_rstudio_foreground !important;
   .rstudio-themes-background {
@@ -248,7 +248,7 @@ $ui_rstudio_is_dark: true;
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: $ui_rstudio_tabs_inactive_background !important;
   .gwt-Label {
@@ -257,7 +257,7 @@ table.rstheme_tabLayoutCenter,
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   .rstheme_center,
   .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
     background: $ui_rstudio_tabs_active_background !important;
@@ -270,7 +270,7 @@ table.rstheme_tabLayoutCenter,
   }
 }
 
-.rstudio-themes-flat {
+.rstudio-themes-dark-menus {
   .rstheme_toolbarWrapper {
     background: $ui_rstudio_toolbar_background !important;
     button, a, div {
@@ -294,11 +294,11 @@ table.rstheme_tabLayoutCenter,
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
      background: $ui_rstudio_toolbar_background !important;
 }
 /* menu background */
-.rstudio-themes-flat {
+.rstudio-themes-dark-menus {
   .popupMiddleCenter,
   .menuPopupMiddleCenter,
   .suggestPopupMiddleCenter {
@@ -355,7 +355,7 @@ table.rstheme_tabLayoutCenter,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
   .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
     background: $ui_rstudio_tabs_inactive_background !important;
@@ -380,9 +380,9 @@ table.rstheme_tabLayoutCenter,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat {
+.rstudio-themes-dark-menus {
   .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-  .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar,
+  .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar,
   &.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
     background-color: unset;
   }
@@ -390,7 +390,7 @@ table.rstheme_tabLayoutCenter,
     overflow: visible;
   }
 }
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: $ui_rstudio_scrollbar_handle $ui_rstudio_scrollbar_background;

--- a/inst/templates/rstudio/_rstudio-dark.scss
+++ b/inst/templates/rstudio/_rstudio-dark.scss
@@ -13,7 +13,7 @@ $ui_rstudio_is_dark: true;
   background-color: $ui_background;
   color: $ui_foreground;
 }
-.rstudio-themes-dark-menus {
+body {
   &.ace_editor_theme {
     background-color: $ui_background;
     color: $ui_foreground;
@@ -248,7 +248,7 @@ $ui_rstudio_is_dark: true;
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: $ui_rstudio_tabs_inactive_background !important;
   .gwt-Label {
@@ -257,7 +257,7 @@ table.rstheme_tabLayoutCenter,
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   .rstheme_center,
   .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
     background: $ui_rstudio_tabs_active_background !important;
@@ -270,7 +270,7 @@ table.rstheme_tabLayoutCenter,
   }
 }
 
-.rstudio-themes-dark-menus {
+body {
   .rstheme_toolbarWrapper {
     background: $ui_rstudio_toolbar_background !important;
     button, a, div {
@@ -283,7 +283,7 @@ table.rstheme_tabLayoutCenter,
       background: transparent !important;
     }
   }
-  .rstudio-themes-dark .search, &.rstudio-themes-dark-menus .search {
+  .rstudio-themes-dark .search, &body .search {
     /* search */
     background: $ui_rstudio_search !important;
   }
@@ -294,11 +294,11 @@ table.rstheme_tabLayoutCenter,
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
      background: $ui_rstudio_toolbar_background !important;
 }
 /* menu background */
-.rstudio-themes-dark-menus {
+body {
   .popupMiddleCenter,
   .menuPopupMiddleCenter,
   .suggestPopupMiddleCenter {
@@ -339,8 +339,8 @@ table.rstheme_tabLayoutCenter,
       }
     }
   }
-  &.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected,
-  &.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+  &body .gwt-MenuItem.gwt-MenuItem-selected,
+  &body .gwt-MenuItem.gwt-MenuItem-selected > table {
     background: $ui_completions_selected_background;
     color: $ui_completions_selected_foreground;
   }
@@ -355,7 +355,7 @@ table.rstheme_tabLayoutCenter,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
   .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
     background: $ui_rstudio_tabs_inactive_background !important;
@@ -380,17 +380,17 @@ table.rstheme_tabLayoutCenter,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus {
+body {
   .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-  .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar,
-  &.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+  body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar,
+  &body .rstudio-themes-scrollbars ::-webkit-scrollbar {
     background-color: unset;
   }
   .ace_scroller {
     overflow: visible;
   }
 }
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: $ui_rstudio_scrollbar_handle $ui_rstudio_scrollbar_background;

--- a/inst/templates/rstudio/_rstudio-light-flatter.scss
+++ b/inst/templates/rstudio/_rstudio-light-flatter.scss
@@ -3,27 +3,27 @@
 // custom flatter styles
 
 /* borders on toolbar under editor */
-.rstudio-themes-light-menus table.rstudio-themes-background td > div:first-child {
+body table.rstudio-themes-background td > div:first-child {
   border-color: $ui_rstudio_background !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 
 /* splitters */
-.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
+body > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
   border-color: $ui_rstudio_background;
 }
 
-.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   border-color: $ui_rstudio_background;
 }
 
-.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel td {
+body > .rstudio-themes-default .gwt-SplitLayoutPanel td {
   border-color: $ui_background !important;
 }
 
 /* window containers */
-.rstudio-themes-light-menus
+body
   > .rstudio-themes-default
   :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
   > div:last-child {

--- a/inst/templates/rstudio/_rstudio-light-flatter.scss
+++ b/inst/templates/rstudio/_rstudio-light-flatter.scss
@@ -3,27 +3,27 @@
 // custom flatter styles
 
 /* borders on toolbar under editor */
-.rstudio-themes-flat table.rstudio-themes-background td > div:first-child {
+.rstudio-themes-light-menus table.rstudio-themes-background td > div:first-child {
   border-color: $ui_rstudio_background !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 
 /* splitters */
-.rstudio-themes-flat > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
+.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
   border-color: $ui_rstudio_background;
 }
 
-.rstudio-themes-flat > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   border-color: $ui_rstudio_background;
 }
 
-.rstudio-themes-flat > .rstudio-themes-default .gwt-SplitLayoutPanel td {
+.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel td {
   border-color: $ui_background !important;
 }
 
 /* window containers */
-.rstudio-themes-flat
+.rstudio-themes-light-menus
   > .rstudio-themes-default
   :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
   > div:last-child {

--- a/inst/templates/rstudio/_rstudio-light.scss
+++ b/inst/templates/rstudio/_rstudio-light.scss
@@ -13,7 +13,7 @@ $ui_rstudio_is_dark: false;
   background-color: $ui_background;
   color: $ui_foreground;
 }
-.rstudio-themes-light-menus {
+body {
   &.ace_editor_theme {
     background-color: $ui_background;
     color: $ui_foreground;
@@ -262,7 +262,7 @@ $ui_rstudio_is_dark: false;
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   background: $ui_rstudio_background !important;
   color: $ui_rstudio_foreground !important;
   .rstudio-themes-background {
@@ -283,7 +283,7 @@ $ui_rstudio_is_dark: false;
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: $ui_rstudio_tabs_inactive_background !important;
   .gwt-Label {
@@ -292,7 +292,7 @@ table.rstheme_tabLayoutCenter,
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   .rstheme_center,
   .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
     background: $ui_rstudio_tabs_active_background !important;
@@ -306,7 +306,7 @@ table.rstheme_tabLayoutCenter,
 }
 
 
-.rstudio-themes-light-menus {
+body {
   .rstheme_toolbarWrapper {
     background: $ui_rstudio_toolbar_background !important;
     button, a, div {
@@ -330,11 +330,11 @@ table.rstheme_tabLayoutCenter,
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
+.rstheme_secondaryToolbar, body .dataGridHeader {
   background: $ui_rstudio_toolbar_background !important;
 }
 /* menu background */
-.rstudio-themes-light-menus {
+body {
   .popupMiddleCenter,
   .menuPopupMiddleCenter,
   .suggestPopupMiddleCenter {
@@ -375,15 +375,15 @@ table.rstheme_tabLayoutCenter,
       }
     }
   }
-  &.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected,
-  &.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+  &body .gwt-MenuItem.gwt-MenuItem-selected,
+  &body .gwt-MenuItem.gwt-MenuItem-selected > table {
     background: $ui_completions_selected_background;
     color: $ui_completions_selected_foreground;
   }
 }
 
 /* hacky toolbars section */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
   .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
     background: $ui_rstudio_tabs_inactive_background !important;
@@ -409,7 +409,7 @@ table.rstheme_tabLayoutCenter,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-light-menus {
+body {
   .rstudio-themes-scrollbars ::-webkit-scrollbar {
     background-color: unset;
   }
@@ -417,7 +417,7 @@ table.rstheme_tabLayoutCenter,
     overflow: visible;
   }
 }
-.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
+body, body .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: $ui_rstudio_scrollbar_handle $ui_rstudio_scrollbar_background;

--- a/inst/templates/rstudio/_rstudio-light.scss
+++ b/inst/templates/rstudio/_rstudio-light.scss
@@ -13,7 +13,7 @@ $ui_rstudio_is_dark: false;
   background-color: $ui_background;
   color: $ui_foreground;
 }
-.rstudio-themes-flat {
+.rstudio-themes-light-menus {
   &.ace_editor_theme {
     background-color: $ui_background;
     color: $ui_foreground;
@@ -262,7 +262,7 @@ $ui_rstudio_is_dark: false;
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   background: $ui_rstudio_background !important;
   color: $ui_rstudio_foreground !important;
   .rstudio-themes-background {
@@ -283,7 +283,7 @@ $ui_rstudio_is_dark: false;
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: $ui_rstudio_tabs_inactive_background !important;
   .gwt-Label {
@@ -292,7 +292,7 @@ table.rstheme_tabLayoutCenter,
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   .rstheme_center,
   .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
     background: $ui_rstudio_tabs_active_background !important;
@@ -306,7 +306,7 @@ table.rstheme_tabLayoutCenter,
 }
 
 
-.rstudio-themes-flat {
+.rstudio-themes-light-menus {
   .rstheme_toolbarWrapper {
     background: $ui_rstudio_toolbar_background !important;
     button, a, div {
@@ -330,11 +330,11 @@ table.rstheme_tabLayoutCenter,
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
   background: $ui_rstudio_toolbar_background !important;
 }
 /* menu background */
-.rstudio-themes-flat {
+.rstudio-themes-light-menus {
   .popupMiddleCenter,
   .menuPopupMiddleCenter,
   .suggestPopupMiddleCenter {
@@ -383,7 +383,7 @@ table.rstheme_tabLayoutCenter,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
   .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
     background: $ui_rstudio_tabs_inactive_background !important;
@@ -409,7 +409,7 @@ table.rstheme_tabLayoutCenter,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat {
+.rstudio-themes-light-menus {
   .rstudio-themes-scrollbars ::-webkit-scrollbar {
     background-color: unset;
   }
@@ -417,7 +417,7 @@ table.rstheme_tabLayoutCenter,
     overflow: visible;
   }
 }
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: $ui_rstudio_scrollbar_handle $ui_rstudio_scrollbar_background;

--- a/inst/templates/serendipity-dark.scss
+++ b/inst/templates/serendipity-dark.scss
@@ -112,7 +112,7 @@ $terminal_color_white_bright: lighten($terminal_color_white, 10%);
   .ace_comment {
     font-style: italic;
   }
-  .rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected {
+  body .gwt-TabLayoutPanelTab-selected {
     .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
       box-shadow: 0 2px 0 $red inset;
       border-radius: 0 !important;

--- a/inst/templates/serendipity-dark.scss
+++ b/inst/templates/serendipity-dark.scss
@@ -112,7 +112,7 @@ $terminal_color_white_bright: lighten($terminal_color_white, 10%);
   .ace_comment {
     font-style: italic;
   }
-  .rstudio-themes-flat .gwt-TabLayoutPanelTab-selected {
+  .rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected {
     .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
       box-shadow: 0 2px 0 $red inset;
       border-radius: 0 !important;

--- a/inst/templates/serendipity-light.scss
+++ b/inst/templates/serendipity-light.scss
@@ -112,7 +112,7 @@ $terminal_color_white_bright: lighten($terminal_color_white, 10%);
   .ace_comment {
     font-style: italic;
   }
-  .rstudio-themes-flat .gwt-TabLayoutPanelTab-selected {
+  .rstudio-themes-light-menus .gwt-TabLayoutPanelTab-selected {
     .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
       box-shadow: 0 2px 0 $red inset;
       border-radius: 0 !important;

--- a/inst/templates/serendipity-light.scss
+++ b/inst/templates/serendipity-light.scss
@@ -112,7 +112,7 @@ $terminal_color_white_bright: lighten($terminal_color_white, 10%);
   .ace_comment {
     font-style: italic;
   }
-  .rstudio-themes-light-menus .gwt-TabLayoutPanelTab-selected {
+  body .gwt-TabLayoutPanelTab-selected {
     .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
       box-shadow: 0 2px 0 $red inset;
       border-radius: 0 !important;

--- a/inst/templates/serendipity.R
+++ b/inst/templates/serendipity.R
@@ -114,7 +114,7 @@ rstheme(
   .ace_comment {
     font-style: italic;
   }
-  .rstudio-themes-flat .gwt-TabLayoutPanelTab-selected {
+  .rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected {
     .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
       box-shadow: 0 2px 0 $red inset;
       border-radius: 0 !important;
@@ -199,7 +199,7 @@ rstheme(
   .ace_comment {
     font-style: italic;
   }
-  .rstudio-themes-flat .gwt-TabLayoutPanelTab-selected {
+  .rstudio-themes-light-menus .gwt-TabLayoutPanelTab-selected {
     .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
       box-shadow: 0 2px 0 $red inset;
       border-radius: 0 !important;

--- a/inst/templates/serendipity.R
+++ b/inst/templates/serendipity.R
@@ -114,7 +114,7 @@ rstheme(
   .ace_comment {
     font-style: italic;
   }
-  .rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected {
+  body .gwt-TabLayoutPanelTab-selected {
     .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
       box-shadow: 0 2px 0 $red inset;
       border-radius: 0 !important;
@@ -199,7 +199,7 @@ rstheme(
   .ace_comment {
     font-style: italic;
   }
-  .rstudio-themes-light-menus .gwt-TabLayoutPanelTab-selected {
+  body .gwt-TabLayoutPanelTab-selected {
     .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
       box-shadow: 0 2px 0 $red inset;
       border-radius: 0 !important;

--- a/inst/themes/a11y-dark.rstheme
+++ b/inst/themes/a11y-dark.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: a11y-dark {rsthemes} */
 /* rs-theme-is-dark: TRUE */
@@ -17,26 +17,26 @@
   color: #FEFEFE;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #2B2B2B;
   color: #FEFEFE;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #2B2B2B;
   color: #FEFEFE;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #2B2B2B;
   color: #FEFEFE;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #FEFEFE;
 }
 
@@ -271,134 +271,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #2B2B2B !important;
   color: #FEFEFE !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #2B2B2B !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #2B2B2B;
   border-color: #2B2B2B;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #2B2B2B;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #303030 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: rgba(254, 254, 254, 0.6);
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #1e1e1e !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #FEFEFE;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #303030 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #1e1e1e !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #FEFEFE !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #1e1e1e !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #E56D75;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #1e1e1e !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #2B2B2B !important;
   color: #FEFEFE !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #FEFEFE !important;
   background: #473245 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #2B2B2B;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #2B2B2B;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #2B2B2B;
   color: #FEFEFE;
   border-color: #2B2B2B;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #2B2B2B;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #2B2B2B;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #FEFEFE;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #2B2B2B;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #473245;
   color: #FEFEFE;
 }
@@ -412,15 +412,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #303030 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #303030 !important;
 }
 
@@ -442,37 +442,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #1e1e1e rgba(43, 43, 43, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(43, 43, 43, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #1e1e1e;
   border-radius: 0px;
   border: 2px solid #2B2B2B;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #2b2b2b;
 }
 
@@ -494,16 +494,16 @@ table.rstheme_tabLayoutCenter .gwt-Label,
   font-weight: 600;
 }
 
-.rstudio-themes-flat .rstudio-themes-border,
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child,
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_minimizedWindowObject,
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_minimizedWindowObject > div:last-child,
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_minimizedWindowObject table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_minimizedWindowObject table.rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_toolbarWrapper,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanel > div > div.gwt-TabLayoutPanelTabs {
+.rstudio-themes-dark-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstudio-themes-background,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_minimizedWindowObject,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_minimizedWindowObject > div:last-child,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_minimizedWindowObject table.rstheme_tabLayoutCenter,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_minimizedWindowObject table.rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_toolbarWrapper,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanel > div > div.gwt-TabLayoutPanelTabs {
   border-color: #454545;
 }
 
@@ -2640,35 +2640,49 @@ input#rstudio_command_palette_search {
   border-color: #2B2B2B;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #2B2B2B;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #2B2B2B;
   color: #FEFEFE;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #383838;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #454545;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/a11y-dark.rstheme
+++ b/inst/themes/a11y-dark.rstheme
@@ -17,26 +17,26 @@
   color: #FEFEFE;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #2B2B2B;
   color: #FEFEFE;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #2B2B2B;
   color: #FEFEFE;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #2B2B2B;
   color: #FEFEFE;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #FEFEFE;
 }
 
@@ -293,112 +293,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #303030 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: rgba(254, 254, 254, 0.6);
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #1e1e1e !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #FEFEFE;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #303030 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #1e1e1e !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #FEFEFE !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #1e1e1e !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #E56D75;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #1e1e1e !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #2B2B2B !important;
   color: #FEFEFE !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #FEFEFE !important;
   background: #473245 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #2B2B2B;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #2B2B2B;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #2B2B2B;
   color: #FEFEFE;
   border-color: #2B2B2B;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #2B2B2B;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #2B2B2B;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #FEFEFE;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #2B2B2B;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #473245;
   color: #FEFEFE;
 }
@@ -412,15 +412,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #303030 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #303030 !important;
 }
 
@@ -442,37 +442,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #1e1e1e rgba(43, 43, 43, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(43, 43, 43, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #1e1e1e;
   border-radius: 0px;
   border: 2px solid #2B2B2B;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #2b2b2b;
 }
 
@@ -494,16 +494,16 @@ table.rstheme_tabLayoutCenter .gwt-Label,
   font-weight: 600;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstudio-themes-background,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_minimizedWindowObject,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_minimizedWindowObject > div:last-child,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_minimizedWindowObject table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_minimizedWindowObject table.rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_toolbarWrapper,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanel > div > div.gwt-TabLayoutPanelTabs {
+body .rstudio-themes-border,
+body .rstudio-themes-dark-grey .windowframe > div:last-child,
+body .rstudio-themes-dark-grey .rstudio-themes-background,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+body .rstudio-themes-dark-grey .rstheme_minimizedWindowObject,
+body .rstudio-themes-dark-grey .rstheme_minimizedWindowObject > div:last-child,
+body .rstudio-themes-dark-grey .rstheme_minimizedWindowObject table.rstheme_tabLayoutCenter,
+body .rstudio-themes-dark-grey .rstheme_minimizedWindowObject table.rstheme_center,
+body .rstudio-themes-dark-grey .rstheme_toolbarWrapper,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanel > div > div.gwt-TabLayoutPanelTabs {
   border-color: #454545;
 }
 
@@ -2640,49 +2640,49 @@ input#rstudio_command_palette_search {
   border-color: #2B2B2B;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #2B2B2B;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #2B2B2B;
   color: #FEFEFE;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #383838;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #454545;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/a11y-light.rstheme
+++ b/inst/themes/a11y-light.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: a11y-light {rsthemes} */
 /* rs-theme-is-dark: FALSE */
@@ -17,35 +17,35 @@
   color: #2B2B2B;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-light-menus.ace_editor_theme {
   background-color: #FEFEFE;
   color: #2B2B2B;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #FEFEFE;
   color: #2B2B2B;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-light-menus .ace_editor_theme {
   background-color: #FEFEFE !important;
   color: #2B2B2B !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table {
+.rstudio-themes-light-menus .ace_editor_theme table {
   background-color: #FEFEFE !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table thead > tr > th {
+.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
   background-color: #FEFEFE !important;
 }
 
-.rstudio-themes-flat.ace_editor_theme a {
+.rstudio-themes-light-menus.ace_editor_theme a {
   color: #2B2B2B !important;
   font-weight: bold;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-light-menus .gwt-Label {
   color: #2B2B2B;
 }
 
@@ -310,148 +310,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   background: #FEFEFE !important;
   color: #2B2B2B !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
   background: #FEFEFE !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #FEFEFE;
   border-color: #FEFEFE;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
   border-color: #FEFEFE;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: white !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: rgba(43, 43, 43, 0.6);
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-default .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #f1f1f1 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #2B2B2B;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: white !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper {
   background: #f1f1f1 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
   color: #2B2B2B !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .search, .rstudio-themes-flat.rstudio-themes-default-menus .search {
+.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
   /* search */
   background: #f1f1f1 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #ba2121;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
   background: #f1f1f1 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-light-menus .popupMiddleCenter,
+.rstudio-themes-light-menus .menuPopupMiddleCenter,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter {
   background: #FEFEFE !important;
   color: #2B2B2B !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #2B2B2B !important;
   background: #4254a7 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-light-menus .themedPopupPanel {
   border: solid 1px #ededed;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #ededed;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-light-menus .popupContent {
   background: #FEFEFE;
   color: #2B2B2B;
   border-color: #ededed;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #ededed;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
   background: #FEFEFE;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
   background: #2B2B2B;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #FEFEFE;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #4254a7;
   color: #2B2B2B;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: white !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: white !important;
 }
 
@@ -473,36 +473,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-light-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #f1f1f1 rgba(254, 254, 254, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(254, 254, 254, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #f1f1f1;
   border-radius: 0px;
   border: 2px solid #FEFEFE;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #e5e5e5;
 }
 
@@ -2657,35 +2657,49 @@ input#rstudio_command_palette_search {
   border-color: #FEFEFE;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #FEFEFE;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #FEFEFE;
   color: #2B2B2B;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #f1f1f1;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #e5e5e5;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/a11y-light.rstheme
+++ b/inst/themes/a11y-light.rstheme
@@ -17,35 +17,35 @@
   color: #2B2B2B;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #FEFEFE;
   color: #2B2B2B;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #FEFEFE;
   color: #2B2B2B;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #FEFEFE !important;
   color: #2B2B2B !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table {
+body .ace_editor_theme table {
   background-color: #FEFEFE !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
+body .ace_editor_theme table thead > tr > th {
   background-color: #FEFEFE !important;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme a {
+body.ace_editor_theme a {
   color: #2B2B2B !important;
   font-weight: bold;
 }
 
-.rstudio-themes-light-menus .gwt-Label {
+body .gwt-Label {
   color: #2B2B2B;
 }
 
@@ -310,148 +310,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   background: #FEFEFE !important;
   color: #2B2B2B !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
+body .rstudio-themes-default .rstudio-themes-background {
   background: #FEFEFE !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+body .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+body .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #FEFEFE;
   border-color: #FEFEFE;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
+body .rstudio-themes-default .rstudio-themes-border {
   border-color: #FEFEFE;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: white !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: rgba(43, 43, 43, 0.6);
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-default .rstheme_center,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #f1f1f1 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #2B2B2B;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: white !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #f1f1f1 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #2B2B2B !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
+body .search, body.rstudio-themes-default-menus .search {
   /* search */
   background: #f1f1f1 !important;
 }
 
-.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #ba2121;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
+.rstheme_secondaryToolbar, body .dataGridHeader {
   background: #f1f1f1 !important;
 }
 
 /* menu background */
-.rstudio-themes-light-menus .popupMiddleCenter,
-.rstudio-themes-light-menus .menuPopupMiddleCenter,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #FEFEFE !important;
   color: #2B2B2B !important;
 }
 
-.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #2B2B2B !important;
   background: #4254a7 !important;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #ededed;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #ededed;
 }
 
-.rstudio-themes-light-menus .popupContent {
+body .popupContent {
   background: #FEFEFE;
   color: #2B2B2B;
   border-color: #ededed;
 }
 
-.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #ededed;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #FEFEFE;
   padding: 2px;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #2B2B2B;
   border: 0;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #FEFEFE;
 }
 
-.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #4254a7;
   color: #2B2B2B;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: white !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: white !important;
 }
 
@@ -473,36 +473,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-light-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
+body, body .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #f1f1f1 rgba(254, 254, 254, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(254, 254, 254, 0.5);
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #f1f1f1;
   border-radius: 0px;
   border: 2px solid #FEFEFE;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #e5e5e5;
 }
 
@@ -2657,49 +2657,49 @@ input#rstudio_command_palette_search {
   border-color: #FEFEFE;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #FEFEFE;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #FEFEFE;
   color: #2B2B2B;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #f1f1f1;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #e5e5e5;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-3024.rstheme
+++ b/inst/themes/base16/base16-3024.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 3024 {rsthemes} */
 /* 3024 by Jan T. Sott (http://github.com/idleberg) */
@@ -18,26 +18,26 @@
   color: #f7f7f7;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #090300;
   color: #f7f7f7;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #090300;
   color: #f7f7f7;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #090300;
   color: #f7f7f7;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #f7f7f7;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #3a3432 !important;
   color: #f7f7f7 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #3a3432 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #3a3432;
   border-color: #090300;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #090300;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #3a3432 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #807d7c;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #4a4543 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f7f7f7;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #3a3432 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #4a4543 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #f7f7f7 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #4a4543 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #cdab53;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #4a4543 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #090300 !important;
   color: #f7f7f7 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #f7f7f7 !important;
   background: #4a4543 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #4a4543;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #4a4543;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #090300;
   color: #f7f7f7;
   border-color: #4a4543;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #4a4543;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #090300;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #f7f7f7;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #090300;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #4a4543;
   color: #f7f7f7;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #3a3432 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #3a3432 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #3a3432 rgba(9, 3, 0, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(9, 3, 0, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #3a3432;
   border-radius: 0px;
   border: 2px solid #090300;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #48403e;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #090300;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #090300;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #090300;
   color: #f7f7f7;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #230c00;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3c1400;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-3024.rstheme
+++ b/inst/themes/base16/base16-3024.rstheme
@@ -18,26 +18,26 @@
   color: #f7f7f7;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #090300;
   color: #f7f7f7;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #090300;
   color: #f7f7f7;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #090300;
   color: #f7f7f7;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #f7f7f7;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #3a3432 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #807d7c;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #4a4543 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f7f7f7;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #3a3432 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #4a4543 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #f7f7f7 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #4a4543 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #cdab53;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #4a4543 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #090300 !important;
   color: #f7f7f7 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #f7f7f7 !important;
   background: #4a4543 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #4a4543;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #4a4543;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #090300;
   color: #f7f7f7;
   border-color: #4a4543;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #4a4543;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #090300;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #f7f7f7;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #090300;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #4a4543;
   color: #f7f7f7;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #3a3432 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #3a3432 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #3a3432 rgba(9, 3, 0, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(9, 3, 0, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #3a3432;
   border-radius: 0px;
   border: 2px solid #090300;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #48403e;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #090300;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #090300;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #090300;
   color: #f7f7f7;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #230c00;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3c1400;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-apathy.rstheme
+++ b/inst/themes/base16/base16-apathy.rstheme
@@ -18,26 +18,26 @@
   color: #D2E7E4;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #031A16;
   color: #D2E7E4;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #031A16;
   color: #D2E7E4;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #031A16;
   color: #D2E7E4;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #D2E7E4;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #0B342D !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #5F9C92;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #184E45 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #D2E7E4;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #0B342D !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #184E45 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #D2E7E4 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #184E45 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #3E965B;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #184E45 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #031A16 !important;
   color: #D2E7E4 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #D2E7E4 !important;
   background: #184E45 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #184E45;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #184E45;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #031A16;
   color: #D2E7E4;
   border-color: #184E45;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #184E45;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #031A16;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #D2E7E4;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #031A16;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #184E45;
   color: #D2E7E4;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #0B342D !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #0B342D !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #0B342D rgba(3, 26, 22, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(3, 26, 22, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #0B342D;
   border-radius: 0px;
   border: 2px solid #031A16;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #0f493f;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #031A16;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #031A16;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #031A16;
   color: #D2E7E4;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #063129;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #08483d;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-apathy.rstheme
+++ b/inst/themes/base16/base16-apathy.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Apathy {rsthemes} */
 /* Apathy by Jannik Siebert (https://github.com/janniks) */
@@ -18,26 +18,26 @@
   color: #D2E7E4;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #031A16;
   color: #D2E7E4;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #031A16;
   color: #D2E7E4;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #031A16;
   color: #D2E7E4;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #D2E7E4;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #0B342D !important;
   color: #D2E7E4 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #0B342D !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #0B342D;
   border-color: #031A16;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #031A16;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #0B342D !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #5F9C92;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #184E45 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #D2E7E4;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #0B342D !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #184E45 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #D2E7E4 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #184E45 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #3E965B;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #184E45 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #031A16 !important;
   color: #D2E7E4 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #D2E7E4 !important;
   background: #184E45 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #184E45;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #184E45;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #031A16;
   color: #D2E7E4;
   border-color: #184E45;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #184E45;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #031A16;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #D2E7E4;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #031A16;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #184E45;
   color: #D2E7E4;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #0B342D !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #0B342D !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #0B342D rgba(3, 26, 22, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(3, 26, 22, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #0B342D;
   border-radius: 0px;
   border: 2px solid #031A16;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #0f493f;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #031A16;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #031A16;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #031A16;
   color: #D2E7E4;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #063129;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #08483d;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-ashes.rstheme
+++ b/inst/themes/base16/base16-ashes.rstheme
@@ -18,26 +18,26 @@
   color: #F3F4F5;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #1C2023;
   color: #F3F4F5;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #1C2023;
   color: #F3F4F5;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #1C2023;
   color: #F3F4F5;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #F3F4F5;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #393F45 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #ADB3BA;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #565E65 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #F3F4F5;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #393F45 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #565E65 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #F3F4F5 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #565E65 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #C79595;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #565E65 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #1C2023 !important;
   color: #F3F4F5 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #F3F4F5 !important;
   background: #565E65 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #565E65;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #565E65;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #1C2023;
   color: #F3F4F5;
   border-color: #565E65;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #565E65;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #1C2023;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #F3F4F5;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1C2023;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #565E65;
   color: #F3F4F5;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #393F45 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #393F45 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #393F45 rgba(28, 32, 35, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(28, 32, 35, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #393F45;
   border-radius: 0px;
   border: 2px solid #1C2023;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #454c53;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #1C2023;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #1C2023;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1C2023;
   color: #F3F4F5;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #272d31;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #333a3f;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-ashes.rstheme
+++ b/inst/themes/base16/base16-ashes.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Ashes {rsthemes} */
 /* Ashes by Jannik Siebert (https://github.com/janniks) */
@@ -18,26 +18,26 @@
   color: #F3F4F5;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #1C2023;
   color: #F3F4F5;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #1C2023;
   color: #F3F4F5;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #1C2023;
   color: #F3F4F5;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #F3F4F5;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #393F45 !important;
   color: #F3F4F5 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #393F45 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #393F45;
   border-color: #1C2023;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #1C2023;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #393F45 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #ADB3BA;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #565E65 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #F3F4F5;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #393F45 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #565E65 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #F3F4F5 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #565E65 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #C79595;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #565E65 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #1C2023 !important;
   color: #F3F4F5 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #F3F4F5 !important;
   background: #565E65 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #565E65;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #565E65;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #1C2023;
   color: #F3F4F5;
   border-color: #565E65;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #565E65;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #1C2023;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #F3F4F5;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1C2023;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #565E65;
   color: #F3F4F5;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #393F45 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #393F45 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #393F45 rgba(28, 32, 35, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(28, 32, 35, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #393F45;
   border-radius: 0px;
   border: 2px solid #1C2023;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #454c53;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #1C2023;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #1C2023;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1C2023;
   color: #F3F4F5;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #272d31;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #333a3f;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-atelier-cave.rstheme
+++ b/inst/themes/base16/base16-atelier-cave.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Atelier Cave {rsthemes} */
 /* Atelier Cave by Bram de Haan (http://atelierbramdehaan.nl) */
@@ -18,26 +18,26 @@
   color: #efecf4;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #19171c;
   color: #efecf4;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #19171c;
   color: #efecf4;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #19171c;
   color: #efecf4;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #efecf4;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #26232a !important;
   color: #efecf4 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #26232a !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #26232a;
   border-color: #19171c;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #19171c;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #26232a !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #7e7887;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #585260 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #efecf4;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #26232a !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #585260 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #efecf4 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #585260 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #bf40bf;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #585260 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #19171c !important;
   color: #efecf4 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #efecf4 !important;
   background: #585260 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #585260;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #585260;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #19171c;
   color: #efecf4;
   border-color: #585260;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #585260;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #19171c;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #efecf4;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #19171c;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #585260;
   color: #efecf4;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #26232a !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #26232a !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #26232a rgba(25, 23, 28, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(25, 23, 28, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #26232a;
   border-radius: 0px;
   border: 2px solid #19171c;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #332f38;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #19171c;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #19171c;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #19171c;
   color: #efecf4;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #26232a;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #322e38;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-atelier-cave.rstheme
+++ b/inst/themes/base16/base16-atelier-cave.rstheme
@@ -18,26 +18,26 @@
   color: #efecf4;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #19171c;
   color: #efecf4;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #19171c;
   color: #efecf4;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #19171c;
   color: #efecf4;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #efecf4;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #26232a !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #7e7887;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #585260 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #efecf4;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #26232a !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #585260 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #efecf4 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #585260 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #bf40bf;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #585260 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #19171c !important;
   color: #efecf4 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #efecf4 !important;
   background: #585260 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #585260;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #585260;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #19171c;
   color: #efecf4;
   border-color: #585260;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #585260;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #19171c;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #efecf4;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #19171c;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #585260;
   color: #efecf4;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #26232a !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #26232a !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #26232a rgba(25, 23, 28, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(25, 23, 28, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #26232a;
   border-radius: 0px;
   border: 2px solid #19171c;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #332f38;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #19171c;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #19171c;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #19171c;
   color: #efecf4;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #26232a;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #322e38;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-atelier-dune.rstheme
+++ b/inst/themes/base16/base16-atelier-dune.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Atelier Dune {rsthemes} */
 /* Atelier Dune by Bram de Haan (http://atelierbramdehaan.nl) */
@@ -18,26 +18,26 @@
   color: #fefbec;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #20201d;
   color: #fefbec;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #20201d;
   color: #fefbec;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #20201d;
   color: #fefbec;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #fefbec;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #292824 !important;
   color: #fefbec !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #292824 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #292824;
   border-color: #20201d;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #20201d;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #292824 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #999580;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #6e6b5e !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #fefbec;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #292824 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #6e6b5e !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #fefbec !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #6e6b5e !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d43552;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #6e6b5e !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #20201d !important;
   color: #fefbec !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #fefbec !important;
   background: #6e6b5e !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #6e6b5e;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #6e6b5e;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #20201d;
   color: #fefbec;
   border-color: #6e6b5e;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #6e6b5e;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #20201d;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #fefbec;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #20201d;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #6e6b5e;
   color: #fefbec;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #292824 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #292824 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #292824 rgba(32, 32, 29, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(32, 32, 29, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #292824;
   border-radius: 0px;
   border: 2px solid #20201d;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #373530;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #20201d;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #20201d;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #20201d;
   color: #fefbec;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #2d2d29;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3b3b35;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-atelier-dune.rstheme
+++ b/inst/themes/base16/base16-atelier-dune.rstheme
@@ -18,26 +18,26 @@
   color: #fefbec;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #20201d;
   color: #fefbec;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #20201d;
   color: #fefbec;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #20201d;
   color: #fefbec;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #fefbec;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #292824 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #999580;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #6e6b5e !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #fefbec;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #292824 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #6e6b5e !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #fefbec !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #6e6b5e !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d43552;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #6e6b5e !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #20201d !important;
   color: #fefbec !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #fefbec !important;
   background: #6e6b5e !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #6e6b5e;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #6e6b5e;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #20201d;
   color: #fefbec;
   border-color: #6e6b5e;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #6e6b5e;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #20201d;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #fefbec;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #20201d;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #6e6b5e;
   color: #fefbec;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #292824 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #292824 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #292824 rgba(32, 32, 29, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(32, 32, 29, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #292824;
   border-radius: 0px;
   border: 2px solid #20201d;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #373530;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #20201d;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #20201d;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #20201d;
   color: #fefbec;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #2d2d29;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3b3b35;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-atelier-estuary.rstheme
+++ b/inst/themes/base16/base16-atelier-estuary.rstheme
@@ -18,26 +18,26 @@
   color: #f4f3ec;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #22221b;
   color: #f4f3ec;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #22221b;
   color: #f4f3ec;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #22221b;
   color: #f4f3ec;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #f4f3ec;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #302f27 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #878573;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #5f5e4e !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f4f3ec;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #302f27 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #5f5e4e !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #f4f3ec !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #5f5e4e !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #9d6c7c;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #5f5e4e !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #22221b !important;
   color: #f4f3ec !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #f4f3ec !important;
   background: #5f5e4e !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #5f5e4e;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #5f5e4e;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #22221b;
   color: #f4f3ec;
   border-color: #5f5e4e;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #5f5e4e;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #22221b;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #f4f3ec;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #22221b;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #5f5e4e;
   color: #f4f3ec;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #302f27 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #302f27 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #302f27 rgba(34, 34, 27, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(34, 34, 27, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #302f27;
   border-radius: 0px;
   border: 2px solid #22221b;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #3e3d32;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #22221b;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #22221b;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #22221b;
   color: #f4f3ec;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #303026;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3e3e32;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-atelier-estuary.rstheme
+++ b/inst/themes/base16/base16-atelier-estuary.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Atelier Estuary {rsthemes} */
 /* Atelier Estuary by Bram de Haan (http://atelierbramdehaan.nl) */
@@ -18,26 +18,26 @@
   color: #f4f3ec;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #22221b;
   color: #f4f3ec;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #22221b;
   color: #f4f3ec;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #22221b;
   color: #f4f3ec;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #f4f3ec;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #302f27 !important;
   color: #f4f3ec !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #302f27 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #302f27;
   border-color: #22221b;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #22221b;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #302f27 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #878573;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #5f5e4e !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f4f3ec;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #302f27 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #5f5e4e !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #f4f3ec !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #5f5e4e !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #9d6c7c;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #5f5e4e !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #22221b !important;
   color: #f4f3ec !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #f4f3ec !important;
   background: #5f5e4e !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #5f5e4e;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #5f5e4e;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #22221b;
   color: #f4f3ec;
   border-color: #5f5e4e;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #5f5e4e;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #22221b;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #f4f3ec;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #22221b;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #5f5e4e;
   color: #f4f3ec;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #302f27 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #302f27 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #302f27 rgba(34, 34, 27, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(34, 34, 27, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #302f27;
   border-radius: 0px;
   border: 2px solid #22221b;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #3e3d32;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #22221b;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #22221b;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #22221b;
   color: #f4f3ec;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #303026;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3e3e32;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-atelier-forest.rstheme
+++ b/inst/themes/base16/base16-atelier-forest.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Atelier Forest {rsthemes} */
 /* Atelier Forest by Bram de Haan (http://atelierbramdehaan.nl) */
@@ -18,26 +18,26 @@
   color: #f1efee;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #1b1918;
   color: #f1efee;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #1b1918;
   color: #f1efee;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #1b1918;
   color: #f1efee;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #f1efee;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #2c2421 !important;
   color: #f1efee !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #2c2421 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #2c2421;
   border-color: #1b1918;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #1b1918;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #2c2421 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #9c9491;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #68615e !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f1efee;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #2c2421 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #68615e !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #f1efee !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #68615e !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #c33ff3;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #68615e !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #1b1918 !important;
   color: #f1efee !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #f1efee !important;
   background: #68615e !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #68615e;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #68615e;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #1b1918;
   color: #f1efee;
   border-color: #68615e;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #68615e;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #1b1918;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #f1efee;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1b1918;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #68615e;
   color: #f1efee;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #2c2421 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #2c2421 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #2c2421 rgba(27, 25, 24, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(27, 25, 24, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #2c2421;
   border-radius: 0px;
   border: 2px solid #1b1918;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #3b302c;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #1b1918;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #1b1918;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1b1918;
   color: #f1efee;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #292624;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #363230;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-atelier-forest.rstheme
+++ b/inst/themes/base16/base16-atelier-forest.rstheme
@@ -18,26 +18,26 @@
   color: #f1efee;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #1b1918;
   color: #f1efee;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #1b1918;
   color: #f1efee;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #1b1918;
   color: #f1efee;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #f1efee;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #2c2421 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #9c9491;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #68615e !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f1efee;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #2c2421 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #68615e !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #f1efee !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #68615e !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #c33ff3;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #68615e !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #1b1918 !important;
   color: #f1efee !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #f1efee !important;
   background: #68615e !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #68615e;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #68615e;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #1b1918;
   color: #f1efee;
   border-color: #68615e;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #68615e;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #1b1918;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #f1efee;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1b1918;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #68615e;
   color: #f1efee;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #2c2421 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #2c2421 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #2c2421 rgba(27, 25, 24, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(27, 25, 24, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #2c2421;
   border-radius: 0px;
   border: 2px solid #1b1918;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #3b302c;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #1b1918;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #1b1918;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1b1918;
   color: #f1efee;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #292624;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #363230;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-atelier-heath.rstheme
+++ b/inst/themes/base16/base16-atelier-heath.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Atelier Heath {rsthemes} */
 /* Atelier Heath by Bram de Haan (http://atelierbramdehaan.nl) */
@@ -18,26 +18,26 @@
   color: #f7f3f7;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #1b181b;
   color: #f7f3f7;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #1b181b;
   color: #f7f3f7;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #1b181b;
   color: #f7f3f7;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #f7f3f7;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #292329 !important;
   color: #f7f3f7 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #292329 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #292329;
   border-color: #1b181b;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #1b181b;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #292329 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #9e8f9e;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #695d69 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f7f3f7;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #292329 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #695d69 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #f7f3f7 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #695d69 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #cc33cc;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #695d69 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #1b181b !important;
   color: #f7f3f7 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #f7f3f7 !important;
   background: #695d69 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #695d69;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #695d69;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #1b181b;
   color: #f7f3f7;
   border-color: #695d69;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #695d69;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #1b181b;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #f7f3f7;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1b181b;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #695d69;
   color: #f7f3f7;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #292329 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #292329 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #292329 rgba(27, 24, 27, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(27, 24, 27, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #292329;
   border-radius: 0px;
   border: 2px solid #1b181b;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #372f37;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #1b181b;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #1b181b;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1b181b;
   color: #f7f3f7;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #292429;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #363036;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-atelier-heath.rstheme
+++ b/inst/themes/base16/base16-atelier-heath.rstheme
@@ -18,26 +18,26 @@
   color: #f7f3f7;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #1b181b;
   color: #f7f3f7;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #1b181b;
   color: #f7f3f7;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #1b181b;
   color: #f7f3f7;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #f7f3f7;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #292329 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #9e8f9e;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #695d69 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f7f3f7;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #292329 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #695d69 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #f7f3f7 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #695d69 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #cc33cc;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #695d69 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #1b181b !important;
   color: #f7f3f7 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #f7f3f7 !important;
   background: #695d69 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #695d69;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #695d69;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #1b181b;
   color: #f7f3f7;
   border-color: #695d69;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #695d69;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #1b181b;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #f7f3f7;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1b181b;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #695d69;
   color: #f7f3f7;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #292329 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #292329 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #292329 rgba(27, 24, 27, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(27, 24, 27, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #292329;
   border-radius: 0px;
   border: 2px solid #1b181b;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #372f37;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #1b181b;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #1b181b;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1b181b;
   color: #f7f3f7;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #292429;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #363036;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-atelier-lakeside.rstheme
+++ b/inst/themes/base16/base16-atelier-lakeside.rstheme
@@ -18,26 +18,26 @@
   color: #ebf8ff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #161b1d;
   color: #ebf8ff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #161b1d;
   color: #ebf8ff;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #161b1d;
   color: #ebf8ff;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #ebf8ff;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #1f292e !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #7195a8;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #516d7b !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ebf8ff;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #1f292e !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #516d7b !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #ebf8ff !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #516d7b !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #b72dd2;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #516d7b !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #161b1d !important;
   color: #ebf8ff !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #ebf8ff !important;
   background: #516d7b !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #516d7b;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #516d7b;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #161b1d;
   color: #ebf8ff;
   border-color: #516d7b;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #516d7b;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #161b1d;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #ebf8ff;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #161b1d;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #516d7b;
   color: #ebf8ff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #1f292e !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #1f292e !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #1f292e rgba(22, 27, 29, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(22, 27, 29, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #1f292e;
   border-radius: 0px;
   border: 2px solid #161b1d;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #29373d;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #161b1d;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #161b1d;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #161b1d;
   color: #ebf8ff;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #21292c;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #2c363a;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-atelier-lakeside.rstheme
+++ b/inst/themes/base16/base16-atelier-lakeside.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Atelier Lakeside {rsthemes} */
 /* Atelier Lakeside by Bram de Haan (http://atelierbramdehaan.nl) */
@@ -18,26 +18,26 @@
   color: #ebf8ff;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #161b1d;
   color: #ebf8ff;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #161b1d;
   color: #ebf8ff;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #161b1d;
   color: #ebf8ff;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #ebf8ff;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #1f292e !important;
   color: #ebf8ff !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #1f292e !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #1f292e;
   border-color: #161b1d;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #161b1d;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #1f292e !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #7195a8;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #516d7b !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ebf8ff;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #1f292e !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #516d7b !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #ebf8ff !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #516d7b !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #b72dd2;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #516d7b !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #161b1d !important;
   color: #ebf8ff !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #ebf8ff !important;
   background: #516d7b !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #516d7b;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #516d7b;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #161b1d;
   color: #ebf8ff;
   border-color: #516d7b;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #516d7b;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #161b1d;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #ebf8ff;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #161b1d;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #516d7b;
   color: #ebf8ff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #1f292e !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #1f292e !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #1f292e rgba(22, 27, 29, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(22, 27, 29, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #1f292e;
   border-radius: 0px;
   border: 2px solid #161b1d;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #29373d;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #161b1d;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #161b1d;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #161b1d;
   color: #ebf8ff;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #21292c;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #2c363a;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-atelier-plateau.rstheme
+++ b/inst/themes/base16/base16-atelier-plateau.rstheme
@@ -18,26 +18,26 @@
   color: #f4ecec;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #1b1818;
   color: #f4ecec;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #1b1818;
   color: #f4ecec;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #1b1818;
   color: #f4ecec;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #f4ecec;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #292424 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #7e7777;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #585050 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f4ecec;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #292424 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #585050 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #f4ecec !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #585050 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #bd5187;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #585050 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #1b1818 !important;
   color: #f4ecec !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #f4ecec !important;
   background: #585050 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #585050;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #585050;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #1b1818;
   color: #f4ecec;
   border-color: #585050;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #585050;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #1b1818;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #f4ecec;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1b1818;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #585050;
   color: #f4ecec;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #292424 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #292424 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #292424 rgba(27, 24, 24, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(27, 24, 24, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #292424;
   border-radius: 0px;
   border: 2px solid #1b1818;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #373030;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #1b1818;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #1b1818;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1b1818;
   color: #f4ecec;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #292424;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #363030;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-atelier-plateau.rstheme
+++ b/inst/themes/base16/base16-atelier-plateau.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Atelier Plateau {rsthemes} */
 /* Atelier Plateau by Bram de Haan (http://atelierbramdehaan.nl) */
@@ -18,26 +18,26 @@
   color: #f4ecec;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #1b1818;
   color: #f4ecec;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #1b1818;
   color: #f4ecec;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #1b1818;
   color: #f4ecec;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #f4ecec;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #292424 !important;
   color: #f4ecec !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #292424 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #292424;
   border-color: #1b1818;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #1b1818;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #292424 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #7e7777;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #585050 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f4ecec;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #292424 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #585050 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #f4ecec !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #585050 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #bd5187;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #585050 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #1b1818 !important;
   color: #f4ecec !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #f4ecec !important;
   background: #585050 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #585050;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #585050;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #1b1818;
   color: #f4ecec;
   border-color: #585050;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #585050;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #1b1818;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #f4ecec;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1b1818;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #585050;
   color: #f4ecec;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #292424 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #292424 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #292424 rgba(27, 24, 24, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(27, 24, 24, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #292424;
   border-radius: 0px;
   border: 2px solid #1b1818;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #373030;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #1b1818;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #1b1818;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1b1818;
   color: #f4ecec;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #292424;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #363030;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-atelier-savanna.rstheme
+++ b/inst/themes/base16/base16-atelier-savanna.rstheme
@@ -18,26 +18,26 @@
   color: #ecf4ee;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #171c19;
   color: #ecf4ee;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #171c19;
   color: #ecf4ee;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #171c19;
   color: #ecf4ee;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #ecf4ee;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #232a25 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #78877d;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #526057 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ecf4ee;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #232a25 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #526057 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #ecf4ee !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #526057 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #867469;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #526057 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #171c19 !important;
   color: #ecf4ee !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #ecf4ee !important;
   background: #526057 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #526057;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #526057;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #171c19;
   color: #ecf4ee;
   border-color: #526057;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #526057;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #171c19;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #ecf4ee;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #171c19;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #526057;
   color: #ecf4ee;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #232a25 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #232a25 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #232a25 rgba(23, 28, 25, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(23, 28, 25, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #232a25;
   border-radius: 0px;
   border: 2px solid #171c19;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #2f3831;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #171c19;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #171c19;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #171c19;
   color: #ecf4ee;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #232a26;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #2e3832;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-atelier-savanna.rstheme
+++ b/inst/themes/base16/base16-atelier-savanna.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Atelier Savanna {rsthemes} */
 /* Atelier Savanna by Bram de Haan (http://atelierbramdehaan.nl) */
@@ -18,26 +18,26 @@
   color: #ecf4ee;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #171c19;
   color: #ecf4ee;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #171c19;
   color: #ecf4ee;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #171c19;
   color: #ecf4ee;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #ecf4ee;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #232a25 !important;
   color: #ecf4ee !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #232a25 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #232a25;
   border-color: #171c19;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #171c19;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #232a25 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #78877d;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #526057 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ecf4ee;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #232a25 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #526057 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #ecf4ee !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #526057 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #867469;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #526057 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #171c19 !important;
   color: #ecf4ee !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #ecf4ee !important;
   background: #526057 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #526057;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #526057;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #171c19;
   color: #ecf4ee;
   border-color: #526057;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #526057;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #171c19;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #ecf4ee;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #171c19;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #526057;
   color: #ecf4ee;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #232a25 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #232a25 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #232a25 rgba(23, 28, 25, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(23, 28, 25, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #232a25;
   border-radius: 0px;
   border: 2px solid #171c19;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #2f3831;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #171c19;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #171c19;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #171c19;
   color: #ecf4ee;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #232a26;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #2e3832;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-atelier-seaside.rstheme
+++ b/inst/themes/base16/base16-atelier-seaside.rstheme
@@ -18,26 +18,26 @@
   color: #f4fbf4;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #131513;
   color: #f4fbf4;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #131513;
   color: #f4fbf4;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #131513;
   color: #f4fbf4;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #f4fbf4;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #242924 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #809980;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #5e6e5e !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f4fbf4;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #242924 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #5e6e5e !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #f4fbf4 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #5e6e5e !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #e619c3;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #5e6e5e !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #131513 !important;
   color: #f4fbf4 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #f4fbf4 !important;
   background: #5e6e5e !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #5e6e5e;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #5e6e5e;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #131513;
   color: #f4fbf4;
   border-color: #5e6e5e;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #5e6e5e;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #131513;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #f4fbf4;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #131513;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #5e6e5e;
   color: #f4fbf4;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #242924 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #242924 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #242924 rgba(19, 21, 19, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(19, 21, 19, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #242924;
   border-radius: 0px;
   border: 2px solid #131513;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #303730;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #131513;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #131513;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #131513;
   color: #f4fbf4;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #1f221f;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #2b302b;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-atelier-seaside.rstheme
+++ b/inst/themes/base16/base16-atelier-seaside.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Atelier Seaside {rsthemes} */
 /* Atelier Seaside by Bram de Haan (http://atelierbramdehaan.nl) */
@@ -18,26 +18,26 @@
   color: #f4fbf4;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #131513;
   color: #f4fbf4;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #131513;
   color: #f4fbf4;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #131513;
   color: #f4fbf4;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #f4fbf4;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #242924 !important;
   color: #f4fbf4 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #242924 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #242924;
   border-color: #131513;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #131513;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #242924 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #809980;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #5e6e5e !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f4fbf4;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #242924 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #5e6e5e !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #f4fbf4 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #5e6e5e !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #e619c3;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #5e6e5e !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #131513 !important;
   color: #f4fbf4 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #f4fbf4 !important;
   background: #5e6e5e !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #5e6e5e;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #5e6e5e;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #131513;
   color: #f4fbf4;
   border-color: #5e6e5e;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #5e6e5e;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #131513;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #f4fbf4;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #131513;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #5e6e5e;
   color: #f4fbf4;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #242924 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #242924 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #242924 rgba(19, 21, 19, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(19, 21, 19, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #242924;
   border-radius: 0px;
   border: 2px solid #131513;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #303730;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #131513;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #131513;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #131513;
   color: #f4fbf4;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #1f221f;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #2b302b;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-atelier-sulphurpool.rstheme
+++ b/inst/themes/base16/base16-atelier-sulphurpool.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Atelier Sulphurpool {rsthemes} */
 /* Atelier Sulphurpool by Bram de Haan (http://atelierbramdehaan.nl) */
@@ -18,26 +18,26 @@
   color: #f5f7ff;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #202746;
   color: #f5f7ff;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #202746;
   color: #f5f7ff;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #202746;
   color: #f5f7ff;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #f5f7ff;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #293256 !important;
   color: #f5f7ff !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #293256 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #293256;
   border-color: #202746;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #202746;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #293256 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #898ea4;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #5e6687 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f5f7ff;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #293256 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #5e6687 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #f5f7ff !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #5e6687 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #9c637a;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #5e6687 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #202746 !important;
   color: #f5f7ff !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #f5f7ff !important;
   background: #5e6687 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #5e6687;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #5e6687;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #202746;
   color: #f5f7ff;
   border-color: #5e6687;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #5e6687;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #202746;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #f5f7ff;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #202746;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #5e6687;
   color: #f5f7ff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #293256 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #293256 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #293256 rgba(32, 39, 70, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(32, 39, 70, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #293256;
   border-radius: 0px;
   border: 2px solid #202746;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #313c67;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #202746;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #202746;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #202746;
   color: #f5f7ff;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #283158;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #303b69;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-atelier-sulphurpool.rstheme
+++ b/inst/themes/base16/base16-atelier-sulphurpool.rstheme
@@ -18,26 +18,26 @@
   color: #f5f7ff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #202746;
   color: #f5f7ff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #202746;
   color: #f5f7ff;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #202746;
   color: #f5f7ff;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #f5f7ff;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #293256 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #898ea4;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #5e6687 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f5f7ff;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #293256 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #5e6687 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #f5f7ff !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #5e6687 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #9c637a;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #5e6687 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #202746 !important;
   color: #f5f7ff !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #f5f7ff !important;
   background: #5e6687 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #5e6687;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #5e6687;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #202746;
   color: #f5f7ff;
   border-color: #5e6687;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #5e6687;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #202746;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #f5f7ff;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #202746;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #5e6687;
   color: #f5f7ff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #293256 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #293256 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #293256 rgba(32, 39, 70, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(32, 39, 70, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #293256;
   border-radius: 0px;
   border: 2px solid #202746;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #313c67;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #202746;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #202746;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #202746;
   color: #f5f7ff;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #283158;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #303b69;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-bespin.rstheme
+++ b/inst/themes/base16/base16-bespin.rstheme
@@ -18,26 +18,26 @@
   color: #baae9e;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #28211c;
   color: #baae9e;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #28211c;
   color: #baae9e;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #28211c;
   color: #baae9e;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #baae9e;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #36312e !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #797977;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #5e5d5c !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #baae9e;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #36312e !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #5e5d5c !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #baae9e !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #5e5d5c !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #937121;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #5e5d5c !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #28211c !important;
   color: #baae9e !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #baae9e !important;
   background: #5e5d5c !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #5e5d5c;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #5e5d5c;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #28211c;
   color: #baae9e;
   border-color: #5e5d5c;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #5e5d5c;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #28211c;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #baae9e;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #28211c;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #5e5d5c;
   color: #baae9e;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #36312e !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #36312e !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #36312e rgba(40, 33, 28, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(40, 33, 28, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #36312e;
   border-radius: 0px;
   border: 2px solid #28211c;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #443d3a;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #28211c;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #28211c;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #28211c;
   color: #baae9e;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #372d27;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #463a31;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-bespin.rstheme
+++ b/inst/themes/base16/base16-bespin.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Bespin {rsthemes} */
 /* Bespin by Jan T. Sott */
@@ -18,26 +18,26 @@
   color: #baae9e;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #28211c;
   color: #baae9e;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #28211c;
   color: #baae9e;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #28211c;
   color: #baae9e;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #baae9e;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #36312e !important;
   color: #baae9e !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #36312e !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #36312e;
   border-color: #28211c;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #28211c;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #36312e !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #797977;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #5e5d5c !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #baae9e;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #36312e !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #5e5d5c !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #baae9e !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #5e5d5c !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #937121;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #5e5d5c !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #28211c !important;
   color: #baae9e !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #baae9e !important;
   background: #5e5d5c !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #5e5d5c;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #5e5d5c;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #28211c;
   color: #baae9e;
   border-color: #5e5d5c;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #5e5d5c;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #28211c;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #baae9e;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #28211c;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #5e5d5c;
   color: #baae9e;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #36312e !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #36312e !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #36312e rgba(40, 33, 28, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(40, 33, 28, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #36312e;
   border-radius: 0px;
   border: 2px solid #28211c;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #443d3a;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #28211c;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #28211c;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #28211c;
   color: #baae9e;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #372d27;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #463a31;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-brewer.rstheme
+++ b/inst/themes/base16/base16-brewer.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 @charset "UTF-8";
 /* rs-theme-name: base16 Brewer {rsthemes} */
@@ -19,26 +19,26 @@
   color: #fcfdfe;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #0c0d0e;
   color: #fcfdfe;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #0c0d0e;
   color: #fcfdfe;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #0c0d0e;
   color: #fcfdfe;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #fcfdfe;
 }
 
@@ -273,134 +273,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #2e2f30 !important;
   color: #fcfdfe !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #2e2f30 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #2e2f30;
   border-color: #0c0d0e;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #0c0d0e;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #2e2f30 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #959697;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #515253 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #fcfdfe;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #2e2f30 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #515253 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #fcfdfe !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #515253 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #b15928;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #515253 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #0c0d0e !important;
   color: #fcfdfe !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #fcfdfe !important;
   background: #515253 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #515253;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #515253;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #0c0d0e;
   color: #fcfdfe;
   border-color: #515253;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #515253;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #0c0d0e;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #fcfdfe;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #0c0d0e;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #515253;
   color: #fcfdfe;
 }
@@ -414,15 +414,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #2e2f30 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #2e2f30 !important;
 }
 
@@ -444,37 +444,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #2e2f30 rgba(12, 13, 14, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(12, 13, 14, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #2e2f30;
   border-radius: 0px;
   border: 2px solid #0c0d0e;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #3a3c3d;
 }
 
@@ -500,35 +500,49 @@ input#rstudio_command_palette_search {
   border-color: #0c0d0e;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #0c0d0e;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #0c0d0e;
   color: #fcfdfe;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #181a1c;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #242729;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-brewer.rstheme
+++ b/inst/themes/base16/base16-brewer.rstheme
@@ -19,26 +19,26 @@
   color: #fcfdfe;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #0c0d0e;
   color: #fcfdfe;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #0c0d0e;
   color: #fcfdfe;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #0c0d0e;
   color: #fcfdfe;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #fcfdfe;
 }
 
@@ -295,112 +295,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #2e2f30 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #959697;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #515253 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #fcfdfe;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #2e2f30 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #515253 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #fcfdfe !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #515253 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #b15928;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #515253 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #0c0d0e !important;
   color: #fcfdfe !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #fcfdfe !important;
   background: #515253 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #515253;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #515253;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #0c0d0e;
   color: #fcfdfe;
   border-color: #515253;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #515253;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #0c0d0e;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #fcfdfe;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #0c0d0e;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #515253;
   color: #fcfdfe;
 }
@@ -414,15 +414,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #2e2f30 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #2e2f30 !important;
 }
 
@@ -444,37 +444,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #2e2f30 rgba(12, 13, 14, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(12, 13, 14, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #2e2f30;
   border-radius: 0px;
   border: 2px solid #0c0d0e;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #3a3c3d;
 }
 
@@ -500,49 +500,49 @@ input#rstudio_command_palette_search {
   border-color: #0c0d0e;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #0c0d0e;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #0c0d0e;
   color: #fcfdfe;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #181a1c;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #242729;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-bright.rstheme
+++ b/inst/themes/base16/base16-bright.rstheme
@@ -18,26 +18,26 @@
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #ffffff;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #303030 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #d0d0d0;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #505050 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #303030 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #505050 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #ffffff !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #505050 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #be643c;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #505050 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #000000 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #ffffff !important;
   background: #505050 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #505050;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #505050;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #000000;
   color: #ffffff;
   border-color: #505050;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #505050;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #000000;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #ffffff;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #000000;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #505050;
   color: #ffffff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #303030 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #303030 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #303030 rgba(0, 0, 0, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(0, 0, 0, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #303030;
   border-radius: 0px;
   border: 2px solid #000000;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #3d3d3d;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #000000;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #000000;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #0d0d0d;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #1a1a1a;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-bright.rstheme
+++ b/inst/themes/base16/base16-bright.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Bright {rsthemes} */
 /* Bright by Chris Kempson (http://chriskempson.com) */
@@ -18,26 +18,26 @@
   color: #ffffff;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #ffffff;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #303030 !important;
   color: #ffffff !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #303030 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #303030;
   border-color: #000000;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #000000;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #303030 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #d0d0d0;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #505050 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #303030 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #505050 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #505050 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #be643c;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #505050 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #000000 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #ffffff !important;
   background: #505050 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #505050;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #505050;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #000000;
   color: #ffffff;
   border-color: #505050;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #505050;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #000000;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #ffffff;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #000000;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #505050;
   color: #ffffff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #303030 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #303030 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #303030 rgba(0, 0, 0, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(0, 0, 0, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #303030;
   border-radius: 0px;
   border: 2px solid #000000;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #3d3d3d;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #000000;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #000000;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #0d0d0d;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #1a1a1a;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-chalk.rstheme
+++ b/inst/themes/base16/base16-chalk.rstheme
@@ -18,26 +18,26 @@
   color: #f5f5f5;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #151515;
   color: #f5f5f5;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #151515;
   color: #f5f5f5;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #151515;
   color: #f5f5f5;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #f5f5f5;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #202020 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #b0b0b0;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #303030 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f5f5f5;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #202020 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #303030 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #f5f5f5 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #303030 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #deaf8f;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #303030 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #151515 !important;
   color: #f5f5f5 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #f5f5f5 !important;
   background: #303030 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #303030;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #303030;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #151515;
   color: #f5f5f5;
   border-color: #303030;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #303030;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #151515;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #f5f5f5;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #151515;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #303030;
   color: #f5f5f5;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #202020 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #202020 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #202020 rgba(21, 21, 21, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(21, 21, 21, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #202020;
   border-radius: 0px;
   border: 2px solid #151515;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #2d2d2d;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #151515;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #151515;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #151515;
   color: #f5f5f5;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #222222;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #2f2f2f;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-chalk.rstheme
+++ b/inst/themes/base16/base16-chalk.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Chalk {rsthemes} */
 /* Chalk by Chris Kempson (http://chriskempson.com) */
@@ -18,26 +18,26 @@
   color: #f5f5f5;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #151515;
   color: #f5f5f5;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #151515;
   color: #f5f5f5;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #151515;
   color: #f5f5f5;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #f5f5f5;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #202020 !important;
   color: #f5f5f5 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #202020 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #202020;
   border-color: #151515;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #151515;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #202020 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #b0b0b0;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #303030 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f5f5f5;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #202020 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #303030 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #f5f5f5 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #303030 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #deaf8f;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #303030 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #151515 !important;
   color: #f5f5f5 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #f5f5f5 !important;
   background: #303030 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #303030;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #303030;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #151515;
   color: #f5f5f5;
   border-color: #303030;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #303030;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #151515;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #f5f5f5;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #151515;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #303030;
   color: #f5f5f5;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #202020 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #202020 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #202020 rgba(21, 21, 21, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(21, 21, 21, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #202020;
   border-radius: 0px;
   border: 2px solid #151515;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #2d2d2d;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #151515;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #151515;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #151515;
   color: #f5f5f5;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #222222;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #2f2f2f;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-codeschool.rstheme
+++ b/inst/themes/base16/base16-codeschool.rstheme
@@ -18,26 +18,26 @@
   color: #b5d8f6;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #232c31;
   color: #b5d8f6;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #232c31;
   color: #b5d8f6;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #232c31;
   color: #b5d8f6;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #b5d8f6;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #1c3657 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #84898c;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #2a343a !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #b5d8f6;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #1c3657 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #2a343a !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #b5d8f6 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #2a343a !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #c98344;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #2a343a !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #232c31 !important;
   color: #b5d8f6 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #b5d8f6 !important;
   background: #2a343a !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #2a343a;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #2a343a;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #232c31;
   color: #b5d8f6;
   border-color: #2a343a;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #2a343a;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #232c31;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #b5d8f6;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #232c31;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #2a343a;
   color: #b5d8f6;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #1c3657 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #1c3657 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #1c3657 rgba(35, 44, 49, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(35, 44, 49, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #1c3657;
   border-radius: 0px;
   border: 2px solid #232c31;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #22426a;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #232c31;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #232c31;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #232c31;
   color: #b5d8f6;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #2e3940;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #38474f;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-codeschool.rstheme
+++ b/inst/themes/base16/base16-codeschool.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Codeschool {rsthemes} */
 /* Codeschool by brettof86 */
@@ -18,26 +18,26 @@
   color: #b5d8f6;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #232c31;
   color: #b5d8f6;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #232c31;
   color: #b5d8f6;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #232c31;
   color: #b5d8f6;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #b5d8f6;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #1c3657 !important;
   color: #b5d8f6 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #1c3657 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #1c3657;
   border-color: #232c31;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #232c31;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #1c3657 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #84898c;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #2a343a !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #b5d8f6;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #1c3657 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #2a343a !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #b5d8f6 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #2a343a !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #c98344;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #2a343a !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #232c31 !important;
   color: #b5d8f6 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #b5d8f6 !important;
   background: #2a343a !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #2a343a;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #2a343a;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #232c31;
   color: #b5d8f6;
   border-color: #2a343a;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #2a343a;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #232c31;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #b5d8f6;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #232c31;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #2a343a;
   color: #b5d8f6;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #1c3657 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #1c3657 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #1c3657 rgba(35, 44, 49, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(35, 44, 49, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #1c3657;
   border-radius: 0px;
   border: 2px solid #232c31;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #22426a;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #232c31;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #232c31;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #232c31;
   color: #b5d8f6;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #2e3940;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #38474f;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-cupcake.rstheme
+++ b/inst/themes/base16/base16-cupcake.rstheme
@@ -18,35 +18,35 @@
   color: #585062;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #fbf1f2;
   color: #585062;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #fbf1f2;
   color: #585062;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #fbf1f2 !important;
   color: #585062 !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table {
+body .ace_editor_theme table {
   background-color: #fbf1f2 !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
+body .ace_editor_theme table thead > tr > th {
   background-color: #fbf1f2 !important;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme a {
+body.ace_editor_theme a {
   color: #585062 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-light-menus .gwt-Label {
+body .gwt-Label {
   color: #585062;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   background: #fbf1f2 !important;
   color: #585062 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
+body .rstudio-themes-default .rstudio-themes-background {
   background: #fbf1f2 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+body .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+body .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #fbf1f2;
   border-color: #fbf1f2;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
+body .rstudio-themes-default .rstudio-themes-border {
   border-color: #fbf1f2;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #d8d5dd !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #bfb9c6;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-default .rstheme_center,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #f2f1f4 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #8b8198;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #d8d5dd !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #f2f1f4 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #585062 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
+body .search, body.rstudio-themes-default-menus .search {
   /* search */
   background: #f2f1f4 !important;
 }
 
-.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #BAA58C;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
+.rstheme_secondaryToolbar, body .dataGridHeader {
   background: #f2f1f4 !important;
 }
 
 /* menu background */
-.rstudio-themes-light-menus .popupMiddleCenter,
-.rstudio-themes-light-menus .menuPopupMiddleCenter,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #fbf1f2 !important;
   color: #585062 !important;
 }
 
-.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #585062 !important;
   background: #d8d5dd !important;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #d8d5dd;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #d8d5dd;
 }
 
-.rstudio-themes-light-menus .popupContent {
+body .popupContent {
   background: #fbf1f2;
   color: #585062;
   border-color: #d8d5dd;
 }
 
-.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #d8d5dd;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #fbf1f2;
   padding: 2px;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #585062;
   border: 0;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #fbf1f2;
 }
 
-.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #d8d5dd;
   color: #585062;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #d8d5dd !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #d8d5dd !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-light-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
+body, body .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #f2f1f4 rgba(251, 241, 242, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(251, 241, 242, 0.5);
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #f2f1f4;
   border-radius: 0px;
   border: 2px solid #fbf1f2;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #e5e3e9;
 }
 
@@ -529,49 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #fbf1f2;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #fbf1f2;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #fbf1f2;
   color: #585062;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #f5dde0;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #f0c9cd;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-cupcake.rstheme
+++ b/inst/themes/base16/base16-cupcake.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Cupcake {rsthemes} */
 /* Cupcake by Chris Kempson (http://chriskempson.com) */
@@ -18,35 +18,35 @@
   color: #585062;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-light-menus.ace_editor_theme {
   background-color: #fbf1f2;
   color: #585062;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #fbf1f2;
   color: #585062;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-light-menus .ace_editor_theme {
   background-color: #fbf1f2 !important;
   color: #585062 !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table {
+.rstudio-themes-light-menus .ace_editor_theme table {
   background-color: #fbf1f2 !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table thead > tr > th {
+.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
   background-color: #fbf1f2 !important;
 }
 
-.rstudio-themes-flat.ace_editor_theme a {
+.rstudio-themes-light-menus.ace_editor_theme a {
   color: #585062 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-light-menus .gwt-Label {
   color: #585062;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   background: #fbf1f2 !important;
   color: #585062 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
   background: #fbf1f2 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #fbf1f2;
   border-color: #fbf1f2;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
   border-color: #fbf1f2;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #d8d5dd !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #bfb9c6;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-default .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #f2f1f4 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #8b8198;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #d8d5dd !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper {
   background: #f2f1f4 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
   color: #585062 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .search, .rstudio-themes-flat.rstudio-themes-default-menus .search {
+.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
   /* search */
   background: #f2f1f4 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #BAA58C;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
   background: #f2f1f4 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-light-menus .popupMiddleCenter,
+.rstudio-themes-light-menus .menuPopupMiddleCenter,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter {
   background: #fbf1f2 !important;
   color: #585062 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #585062 !important;
   background: #d8d5dd !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-light-menus .themedPopupPanel {
   border: solid 1px #d8d5dd;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #d8d5dd;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-light-menus .popupContent {
   background: #fbf1f2;
   color: #585062;
   border-color: #d8d5dd;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #d8d5dd;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
   background: #fbf1f2;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
   background: #585062;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #fbf1f2;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #d8d5dd;
   color: #585062;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #d8d5dd !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #d8d5dd !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-light-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #f2f1f4 rgba(251, 241, 242, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(251, 241, 242, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #f2f1f4;
   border-radius: 0px;
   border: 2px solid #fbf1f2;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #e5e3e9;
 }
 
@@ -529,35 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #fbf1f2;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #fbf1f2;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #fbf1f2;
   color: #585062;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #f5dde0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #f0c9cd;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-darktooth.rstheme
+++ b/inst/themes/base16/base16-darktooth.rstheme
@@ -18,26 +18,26 @@
   color: #FDF4C1;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #1D2021;
   color: #FDF4C1;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #1D2021;
   color: #FDF4C1;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #1D2021;
   color: #FDF4C1;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #FDF4C1;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #32302F !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #928374;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #504945 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #FDF4C1;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #32302F !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #504945 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #FDF4C1 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #504945 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #A87322;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #504945 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #1D2021 !important;
   color: #FDF4C1 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #FDF4C1 !important;
   background: #504945 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #504945;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #504945;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #1D2021;
   color: #FDF4C1;
   border-color: #504945;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #504945;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #1D2021;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #FDF4C1;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1D2021;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #504945;
   color: #FDF4C1;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #32302F !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #32302F !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #32302F rgba(29, 32, 33, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(29, 32, 33, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #32302F;
   border-radius: 0px;
   border: 2px solid #1D2021;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #3f3d3b;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #1D2021;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #1D2021;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1D2021;
   color: #FDF4C1;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #292d2f;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #353a3c;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-darktooth.rstheme
+++ b/inst/themes/base16/base16-darktooth.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Darktooth {rsthemes} */
 /* Darktooth by Jason Milkins (https://github.com/jasonm23) */
@@ -18,26 +18,26 @@
   color: #FDF4C1;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #1D2021;
   color: #FDF4C1;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #1D2021;
   color: #FDF4C1;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #1D2021;
   color: #FDF4C1;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #FDF4C1;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #32302F !important;
   color: #FDF4C1 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #32302F !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #32302F;
   border-color: #1D2021;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #1D2021;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #32302F !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #928374;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #504945 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #FDF4C1;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #32302F !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #504945 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #FDF4C1 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #504945 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #A87322;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #504945 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #1D2021 !important;
   color: #FDF4C1 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #FDF4C1 !important;
   background: #504945 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #504945;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #504945;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #1D2021;
   color: #FDF4C1;
   border-color: #504945;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #504945;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #1D2021;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #FDF4C1;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1D2021;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #504945;
   color: #FDF4C1;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #32302F !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #32302F !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #32302F rgba(29, 32, 33, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(29, 32, 33, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #32302F;
   border-radius: 0px;
   border: 2px solid #1D2021;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #3f3d3b;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #1D2021;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #1D2021;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1D2021;
   color: #FDF4C1;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #292d2f;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #353a3c;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-default-dark.rstheme
+++ b/inst/themes/base16/base16-default-dark.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Default Dark {rsthemes} */
 /* Default Dark by Chris Kempson (http://chriskempson.com) */
@@ -18,26 +18,26 @@
   color: #f8f8f8;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #181818;
   color: #f8f8f8;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #181818;
   color: #f8f8f8;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #181818;
   color: #f8f8f8;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #f8f8f8;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #282828 !important;
   color: #f8f8f8 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #282828 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #282828;
   border-color: #181818;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #181818;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #282828 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #b8b8b8;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #383838 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f8f8f8;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #282828 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #383838 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #f8f8f8 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #383838 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #a16946;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #383838 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #181818 !important;
   color: #f8f8f8 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #f8f8f8 !important;
   background: #383838 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #383838;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #383838;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #181818;
   color: #f8f8f8;
   border-color: #383838;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #383838;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #181818;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #f8f8f8;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #181818;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #383838;
   color: #f8f8f8;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #282828 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #282828 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #282828 rgba(24, 24, 24, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(24, 24, 24, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #282828;
   border-radius: 0px;
   border: 2px solid #181818;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #353535;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #181818;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #181818;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #181818;
   color: #f8f8f8;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #252525;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #323232;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-default-dark.rstheme
+++ b/inst/themes/base16/base16-default-dark.rstheme
@@ -18,26 +18,26 @@
   color: #f8f8f8;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #181818;
   color: #f8f8f8;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #181818;
   color: #f8f8f8;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #181818;
   color: #f8f8f8;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #f8f8f8;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #282828 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #b8b8b8;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #383838 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f8f8f8;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #282828 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #383838 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #f8f8f8 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #383838 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #a16946;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #383838 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #181818 !important;
   color: #f8f8f8 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #f8f8f8 !important;
   background: #383838 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #383838;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #383838;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #181818;
   color: #f8f8f8;
   border-color: #383838;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #383838;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #181818;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #f8f8f8;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #181818;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #383838;
   color: #f8f8f8;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #282828 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #282828 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #282828 rgba(24, 24, 24, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(24, 24, 24, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #282828;
   border-radius: 0px;
   border: 2px solid #181818;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #353535;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #181818;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #181818;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #181818;
   color: #f8f8f8;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #252525;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #323232;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-default-light.rstheme
+++ b/inst/themes/base16/base16-default-light.rstheme
@@ -18,35 +18,35 @@
   color: #181818;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #f8f8f8;
   color: #181818;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #f8f8f8;
   color: #181818;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #f8f8f8 !important;
   color: #181818 !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table {
+body .ace_editor_theme table {
   background-color: #f8f8f8 !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
+body .ace_editor_theme table thead > tr > th {
   background-color: #f8f8f8 !important;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme a {
+body.ace_editor_theme a {
   color: #181818 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-light-menus .gwt-Label {
+body .gwt-Label {
   color: #181818;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   background: #f8f8f8 !important;
   color: #181818 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
+body .rstudio-themes-default .rstudio-themes-background {
   background: #f8f8f8 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+body .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+body .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #f8f8f8;
   border-color: #f8f8f8;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
+body .rstudio-themes-default .rstudio-themes-border {
   border-color: #f8f8f8;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #d8d8d8 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #b8b8b8;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-default .rstheme_center,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #e8e8e8 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #383838;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #d8d8d8 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #e8e8e8 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #181818 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
+body .search, body.rstudio-themes-default-menus .search {
   /* search */
   background: #e8e8e8 !important;
 }
 
-.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #a16946;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
+.rstheme_secondaryToolbar, body .dataGridHeader {
   background: #e8e8e8 !important;
 }
 
 /* menu background */
-.rstudio-themes-light-menus .popupMiddleCenter,
-.rstudio-themes-light-menus .menuPopupMiddleCenter,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #f8f8f8 !important;
   color: #181818 !important;
 }
 
-.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #181818 !important;
   background: #d8d8d8 !important;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #d8d8d8;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #d8d8d8;
 }
 
-.rstudio-themes-light-menus .popupContent {
+body .popupContent {
   background: #f8f8f8;
   color: #181818;
   border-color: #d8d8d8;
 }
 
-.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #d8d8d8;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #f8f8f8;
   padding: 2px;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #181818;
   border: 0;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #f8f8f8;
 }
 
-.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #d8d8d8;
   color: #181818;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #d8d8d8 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #d8d8d8 !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-light-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
+body, body .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #e8e8e8 rgba(248, 248, 248, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(248, 248, 248, 0.5);
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #e8e8e8;
   border-radius: 0px;
   border: 2px solid #f8f8f8;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #dbdbdb;
 }
 
@@ -529,49 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #f8f8f8;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #f8f8f8;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #f8f8f8;
   color: #181818;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #ebebeb;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #dfdfdf;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-default-light.rstheme
+++ b/inst/themes/base16/base16-default-light.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Default Light {rsthemes} */
 /* Default Light by Chris Kempson (http://chriskempson.com) */
@@ -18,35 +18,35 @@
   color: #181818;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-light-menus.ace_editor_theme {
   background-color: #f8f8f8;
   color: #181818;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #f8f8f8;
   color: #181818;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-light-menus .ace_editor_theme {
   background-color: #f8f8f8 !important;
   color: #181818 !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table {
+.rstudio-themes-light-menus .ace_editor_theme table {
   background-color: #f8f8f8 !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table thead > tr > th {
+.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
   background-color: #f8f8f8 !important;
 }
 
-.rstudio-themes-flat.ace_editor_theme a {
+.rstudio-themes-light-menus.ace_editor_theme a {
   color: #181818 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-light-menus .gwt-Label {
   color: #181818;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   background: #f8f8f8 !important;
   color: #181818 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
   background: #f8f8f8 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #f8f8f8;
   border-color: #f8f8f8;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
   border-color: #f8f8f8;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #d8d8d8 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #b8b8b8;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-default .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #e8e8e8 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #383838;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #d8d8d8 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper {
   background: #e8e8e8 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
   color: #181818 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .search, .rstudio-themes-flat.rstudio-themes-default-menus .search {
+.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
   /* search */
   background: #e8e8e8 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #a16946;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
   background: #e8e8e8 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-light-menus .popupMiddleCenter,
+.rstudio-themes-light-menus .menuPopupMiddleCenter,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter {
   background: #f8f8f8 !important;
   color: #181818 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #181818 !important;
   background: #d8d8d8 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-light-menus .themedPopupPanel {
   border: solid 1px #d8d8d8;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #d8d8d8;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-light-menus .popupContent {
   background: #f8f8f8;
   color: #181818;
   border-color: #d8d8d8;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #d8d8d8;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
   background: #f8f8f8;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
   background: #181818;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #f8f8f8;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #d8d8d8;
   color: #181818;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #d8d8d8 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #d8d8d8 !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-light-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #e8e8e8 rgba(248, 248, 248, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(248, 248, 248, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #e8e8e8;
   border-radius: 0px;
   border: 2px solid #f8f8f8;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #dbdbdb;
 }
 
@@ -529,35 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #f8f8f8;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #f8f8f8;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #f8f8f8;
   color: #181818;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #ebebeb;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #dfdfdf;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-dracula.rstheme
+++ b/inst/themes/base16/base16-dracula.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Dracula {rsthemes} */
 /* Dracula by Mike Barkmin (http://github.com/mikebarkmin) based on Dracula Theme (http://github.com/dracula) */
@@ -18,26 +18,26 @@
   color: #f7f7fb;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #282936;
   color: #f7f7fb;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #282936;
   color: #f7f7fb;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #282936;
   color: #f7f7fb;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #f7f7fb;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #3a3c4e !important;
   color: #f7f7fb !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #3a3c4e !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #3a3c4e;
   border-color: #282936;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #282936;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #3a3c4e !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #62d6e8;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #4d4f68 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f7f7fb;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #3a3c4e !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #4d4f68 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #f7f7fb !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #4d4f68 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #00f769;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #4d4f68 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #282936 !important;
   color: #f7f7fb !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #f7f7fb !important;
   background: #4d4f68 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #4d4f68;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #4d4f68;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #282936;
   color: #f7f7fb;
   border-color: #4d4f68;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #4d4f68;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #282936;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #f7f7fb;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #282936;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #4d4f68;
   color: #f7f7fb;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #3a3c4e !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #3a3c4e !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #3a3c4e rgba(40, 41, 54, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(40, 41, 54, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #3a3c4e;
   border-radius: 0px;
   border: 2px solid #282936;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #45475d;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #282936;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #282936;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #282936;
   color: #f7f7fb;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #333445;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3e3f53;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-dracula.rstheme
+++ b/inst/themes/base16/base16-dracula.rstheme
@@ -18,26 +18,26 @@
   color: #f7f7fb;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #282936;
   color: #f7f7fb;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #282936;
   color: #f7f7fb;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #282936;
   color: #f7f7fb;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #f7f7fb;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #3a3c4e !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #62d6e8;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #4d4f68 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f7f7fb;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #3a3c4e !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #4d4f68 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #f7f7fb !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #4d4f68 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #00f769;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #4d4f68 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #282936 !important;
   color: #f7f7fb !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #f7f7fb !important;
   background: #4d4f68 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #4d4f68;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #4d4f68;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #282936;
   color: #f7f7fb;
   border-color: #4d4f68;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #4d4f68;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #282936;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #f7f7fb;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #282936;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #4d4f68;
   color: #f7f7fb;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #3a3c4e !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #3a3c4e !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #3a3c4e rgba(40, 41, 54, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(40, 41, 54, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #3a3c4e;
   border-radius: 0px;
   border: 2px solid #282936;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #45475d;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #282936;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #282936;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #282936;
   color: #f7f7fb;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #333445;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3e3f53;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-eighties.rstheme
+++ b/inst/themes/base16/base16-eighties.rstheme
@@ -18,26 +18,26 @@
   color: #f2f0ec;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #2d2d2d;
   color: #f2f0ec;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #2d2d2d;
   color: #f2f0ec;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #2d2d2d;
   color: #f2f0ec;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #f2f0ec;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #393939 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #a09f93;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #515151 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f2f0ec;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #393939 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #515151 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #f2f0ec !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #515151 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d27b53;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #515151 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #2d2d2d !important;
   color: #f2f0ec !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #f2f0ec !important;
   background: #515151 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #515151;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #515151;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #2d2d2d;
   color: #f2f0ec;
   border-color: #515151;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #515151;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #2d2d2d;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #f2f0ec;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #2d2d2d;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #515151;
   color: #f2f0ec;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #393939 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #393939 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #393939 rgba(45, 45, 45, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(45, 45, 45, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #393939;
   border-radius: 0px;
   border: 2px solid #2d2d2d;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #464646;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #2d2d2d;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #2d2d2d;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #2d2d2d;
   color: #f2f0ec;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #3a3a3a;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #474747;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-eighties.rstheme
+++ b/inst/themes/base16/base16-eighties.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Eighties {rsthemes} */
 /* Eighties by Chris Kempson (http://chriskempson.com) */
@@ -18,26 +18,26 @@
   color: #f2f0ec;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #2d2d2d;
   color: #f2f0ec;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #2d2d2d;
   color: #f2f0ec;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #2d2d2d;
   color: #f2f0ec;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #f2f0ec;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #393939 !important;
   color: #f2f0ec !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #393939 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #393939;
   border-color: #2d2d2d;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #2d2d2d;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #393939 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #a09f93;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #515151 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f2f0ec;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #393939 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #515151 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #f2f0ec !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #515151 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d27b53;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #515151 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #2d2d2d !important;
   color: #f2f0ec !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #f2f0ec !important;
   background: #515151 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #515151;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #515151;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #2d2d2d;
   color: #f2f0ec;
   border-color: #515151;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #515151;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #2d2d2d;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #f2f0ec;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #2d2d2d;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #515151;
   color: #f2f0ec;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #393939 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #393939 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #393939 rgba(45, 45, 45, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(45, 45, 45, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #393939;
   border-radius: 0px;
   border: 2px solid #2d2d2d;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #464646;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #2d2d2d;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #2d2d2d;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #2d2d2d;
   color: #f2f0ec;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #3a3a3a;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #474747;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-embers.rstheme
+++ b/inst/themes/base16/base16-embers.rstheme
@@ -18,26 +18,26 @@
   color: #DBD6D1;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #16130F;
   color: #DBD6D1;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #16130F;
   color: #DBD6D1;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #16130F;
   color: #DBD6D1;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #DBD6D1;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #2C2620 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #8A8075;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #433B32 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #DBD6D1;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #2C2620 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #433B32 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #DBD6D1 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #433B32 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #825757;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #433B32 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #16130F !important;
   color: #DBD6D1 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #DBD6D1 !important;
   background: #433B32 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #433B32;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #433B32;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #16130F;
   color: #DBD6D1;
   border-color: #433B32;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #433B32;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #16130F;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #DBD6D1;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #16130F;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #433B32;
   color: #DBD6D1;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #2C2620 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #2C2620 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #2C2620 rgba(22, 19, 15, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(22, 19, 15, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #2C2620;
   border-radius: 0px;
   border: 2px solid #16130F;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #3b332b;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #16130F;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #16130F;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #16130F;
   color: #DBD6D1;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #252019;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #342d24;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-embers.rstheme
+++ b/inst/themes/base16/base16-embers.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Embers {rsthemes} */
 /* Embers by Jannik Siebert (https://github.com/janniks) */
@@ -18,26 +18,26 @@
   color: #DBD6D1;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #16130F;
   color: #DBD6D1;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #16130F;
   color: #DBD6D1;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #16130F;
   color: #DBD6D1;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #DBD6D1;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #2C2620 !important;
   color: #DBD6D1 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #2C2620 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #2C2620;
   border-color: #16130F;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #16130F;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #2C2620 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #8A8075;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #433B32 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #DBD6D1;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #2C2620 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #433B32 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #DBD6D1 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #433B32 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #825757;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #433B32 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #16130F !important;
   color: #DBD6D1 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #DBD6D1 !important;
   background: #433B32 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #433B32;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #433B32;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #16130F;
   color: #DBD6D1;
   border-color: #433B32;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #433B32;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #16130F;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #DBD6D1;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #16130F;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #433B32;
   color: #DBD6D1;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #2C2620 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #2C2620 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #2C2620 rgba(22, 19, 15, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(22, 19, 15, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #2C2620;
   border-radius: 0px;
   border: 2px solid #16130F;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #3b332b;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #16130F;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #16130F;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #16130F;
   color: #DBD6D1;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #252019;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #342d24;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-flat.rstheme
+++ b/inst/themes/base16/base16-flat.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Flat {rsthemes} */
 /* Flat by Chris Kempson (http://chriskempson.com) */
@@ -18,26 +18,26 @@
   color: #ECF0F1;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #2C3E50;
   color: #ECF0F1;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #2C3E50;
   color: #ECF0F1;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #2C3E50;
   color: #ECF0F1;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #ECF0F1;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #34495E !important;
   color: #ECF0F1 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #34495E !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #34495E;
   border-color: #2C3E50;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #2C3E50;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #34495E !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #BDC3C7;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #7F8C8D !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ECF0F1;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #34495E !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #7F8C8D !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #ECF0F1 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #7F8C8D !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #be643c;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #7F8C8D !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #2C3E50 !important;
   color: #ECF0F1 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #ECF0F1 !important;
   background: #7F8C8D !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #7F8C8D;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #7F8C8D;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #2C3E50;
   color: #ECF0F1;
   border-color: #7F8C8D;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #7F8C8D;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #2C3E50;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #ECF0F1;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #2C3E50;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #7F8C8D;
   color: #ECF0F1;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #34495E !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #34495E !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #34495E rgba(44, 62, 80, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(44, 62, 80, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #34495E;
   border-radius: 0px;
   border: 2px solid #2C3E50;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #3d566e;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #2C3E50;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #2C3E50;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #2C3E50;
   color: #ECF0F1;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #354b60;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3e5871;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-flat.rstheme
+++ b/inst/themes/base16/base16-flat.rstheme
@@ -18,26 +18,26 @@
   color: #ECF0F1;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #2C3E50;
   color: #ECF0F1;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #2C3E50;
   color: #ECF0F1;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #2C3E50;
   color: #ECF0F1;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #ECF0F1;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #34495E !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #BDC3C7;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #7F8C8D !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ECF0F1;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #34495E !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #7F8C8D !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #ECF0F1 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #7F8C8D !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #be643c;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #7F8C8D !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #2C3E50 !important;
   color: #ECF0F1 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #ECF0F1 !important;
   background: #7F8C8D !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #7F8C8D;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #7F8C8D;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #2C3E50;
   color: #ECF0F1;
   border-color: #7F8C8D;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #7F8C8D;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #2C3E50;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #ECF0F1;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #2C3E50;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #7F8C8D;
   color: #ECF0F1;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #34495E !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #34495E !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #34495E rgba(44, 62, 80, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(44, 62, 80, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #34495E;
   border-radius: 0px;
   border: 2px solid #2C3E50;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #3d566e;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #2C3E50;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #2C3E50;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #2C3E50;
   color: #ECF0F1;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #354b60;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3e5871;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-google-dark.rstheme
+++ b/inst/themes/base16/base16-google-dark.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Google Dark {rsthemes} */
 /* Google Dark by Seth Wright (http://sethawright.com) */
@@ -18,26 +18,26 @@
   color: #ffffff;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #1d1f21;
   color: #ffffff;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #1d1f21;
   color: #ffffff;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #1d1f21;
   color: #ffffff;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #ffffff;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #282a2e !important;
   color: #ffffff !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #282a2e !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #282a2e;
   border-color: #1d1f21;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #1d1f21;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #282a2e !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #b4b7b4;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #373b41 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #282a2e !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #373b41 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #373b41 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #3971ED;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #373b41 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #1d1f21 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #ffffff !important;
   background: #373b41 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #373b41;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #373b41;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #1d1f21;
   color: #ffffff;
   border-color: #373b41;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #373b41;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #1d1f21;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #ffffff;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1d1f21;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #373b41;
   color: #ffffff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #282a2e !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #282a2e !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #282a2e rgba(29, 31, 33, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(29, 31, 33, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #282a2e;
   border-radius: 0px;
   border: 2px solid #1d1f21;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #34363c;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #1d1f21;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #1d1f21;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1d1f21;
   color: #ffffff;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #292c2f;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #35393c;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-google-dark.rstheme
+++ b/inst/themes/base16/base16-google-dark.rstheme
@@ -18,26 +18,26 @@
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #1d1f21;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #1d1f21;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #1d1f21;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #ffffff;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #282a2e !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #b4b7b4;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #373b41 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #282a2e !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #373b41 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #ffffff !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #373b41 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #3971ED;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #373b41 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #1d1f21 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #ffffff !important;
   background: #373b41 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #373b41;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #373b41;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #1d1f21;
   color: #ffffff;
   border-color: #373b41;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #373b41;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #1d1f21;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #ffffff;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1d1f21;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #373b41;
   color: #ffffff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #282a2e !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #282a2e !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #282a2e rgba(29, 31, 33, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(29, 31, 33, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #282a2e;
   border-radius: 0px;
   border: 2px solid #1d1f21;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #34363c;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #1d1f21;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #1d1f21;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1d1f21;
   color: #ffffff;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #292c2f;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #35393c;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-google-light.rstheme
+++ b/inst/themes/base16/base16-google-light.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Google Light {rsthemes} */
 /* Google Light by Seth Wright (http://sethawright.com) */
@@ -18,35 +18,35 @@
   color: #1d1f21;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-light-menus.ace_editor_theme {
   background-color: #ffffff;
   color: #1d1f21;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #ffffff;
   color: #1d1f21;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-light-menus .ace_editor_theme {
   background-color: #ffffff !important;
   color: #1d1f21 !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table {
+.rstudio-themes-light-menus .ace_editor_theme table {
   background-color: #ffffff !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table thead > tr > th {
+.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
   background-color: #ffffff !important;
 }
 
-.rstudio-themes-flat.ace_editor_theme a {
+.rstudio-themes-light-menus.ace_editor_theme a {
   color: #1d1f21 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-light-menus .gwt-Label {
   color: #1d1f21;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   background: #ffffff !important;
   color: #1d1f21 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
   background: #ffffff !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #ffffff;
   border-color: #ffffff;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
   border-color: #ffffff;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #c5c8c6 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #b4b7b4;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-default .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #e0e0e0 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #373b41;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #c5c8c6 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper {
   background: #e0e0e0 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
   color: #1d1f21 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .search, .rstudio-themes-flat.rstudio-themes-default-menus .search {
+.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
   /* search */
   background: #e0e0e0 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #3971ED;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
   background: #e0e0e0 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-light-menus .popupMiddleCenter,
+.rstudio-themes-light-menus .menuPopupMiddleCenter,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter {
   background: #ffffff !important;
   color: #1d1f21 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #1d1f21 !important;
   background: #c5c8c6 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-light-menus .themedPopupPanel {
   border: solid 1px #c5c8c6;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #c5c8c6;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-light-menus .popupContent {
   background: #ffffff;
   color: #1d1f21;
   border-color: #c5c8c6;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #c5c8c6;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
   background: #ffffff;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
   background: #1d1f21;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #c5c8c6;
   color: #1d1f21;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #c5c8c6 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #c5c8c6 !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-light-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #e0e0e0 rgba(255, 255, 255, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(255, 255, 255, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #e0e0e0;
   border-radius: 0px;
   border: 2px solid #ffffff;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: lightgray;
 }
 
@@ -529,35 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #ffffff;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #ffffff;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #ffffff;
   color: #1d1f21;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #f2f2f2;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #e6e6e6;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-google-light.rstheme
+++ b/inst/themes/base16/base16-google-light.rstheme
@@ -18,35 +18,35 @@
   color: #1d1f21;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #ffffff;
   color: #1d1f21;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #ffffff;
   color: #1d1f21;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #ffffff !important;
   color: #1d1f21 !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table {
+body .ace_editor_theme table {
   background-color: #ffffff !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
+body .ace_editor_theme table thead > tr > th {
   background-color: #ffffff !important;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme a {
+body.ace_editor_theme a {
   color: #1d1f21 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-light-menus .gwt-Label {
+body .gwt-Label {
   color: #1d1f21;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   background: #ffffff !important;
   color: #1d1f21 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
+body .rstudio-themes-default .rstudio-themes-background {
   background: #ffffff !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+body .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+body .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #ffffff;
   border-color: #ffffff;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
+body .rstudio-themes-default .rstudio-themes-border {
   border-color: #ffffff;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #c5c8c6 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #b4b7b4;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-default .rstheme_center,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #e0e0e0 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #373b41;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #c5c8c6 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #e0e0e0 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #1d1f21 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
+body .search, body.rstudio-themes-default-menus .search {
   /* search */
   background: #e0e0e0 !important;
 }
 
-.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #3971ED;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
+.rstheme_secondaryToolbar, body .dataGridHeader {
   background: #e0e0e0 !important;
 }
 
 /* menu background */
-.rstudio-themes-light-menus .popupMiddleCenter,
-.rstudio-themes-light-menus .menuPopupMiddleCenter,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #ffffff !important;
   color: #1d1f21 !important;
 }
 
-.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #1d1f21 !important;
   background: #c5c8c6 !important;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #c5c8c6;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #c5c8c6;
 }
 
-.rstudio-themes-light-menus .popupContent {
+body .popupContent {
   background: #ffffff;
   color: #1d1f21;
   border-color: #c5c8c6;
 }
 
-.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #c5c8c6;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #ffffff;
   padding: 2px;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #1d1f21;
   border: 0;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #c5c8c6;
   color: #1d1f21;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #c5c8c6 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #c5c8c6 !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-light-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
+body, body .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #e0e0e0 rgba(255, 255, 255, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(255, 255, 255, 0.5);
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #e0e0e0;
   border-radius: 0px;
   border: 2px solid #ffffff;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: lightgray;
 }
 
@@ -529,49 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #ffffff;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #ffffff;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #ffffff;
   color: #1d1f21;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #f2f2f2;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #e6e6e6;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-grayscale-dark.rstheme
+++ b/inst/themes/base16/base16-grayscale-dark.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Grayscale Dark {rsthemes} */
 /* Grayscale Dark by Alexandre Gavioli (https://github.com/Alexx2/) */
@@ -18,26 +18,26 @@
   color: #f7f7f7;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #101010;
   color: #f7f7f7;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #101010;
   color: #f7f7f7;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #101010;
   color: #f7f7f7;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #f7f7f7;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #252525 !important;
   color: #f7f7f7 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #252525 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #252525;
   border-color: #101010;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #101010;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #252525 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #ababab;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #464646 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f7f7f7;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #252525 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #464646 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #f7f7f7 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #464646 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #5e5e5e;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #464646 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #101010 !important;
   color: #f7f7f7 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #f7f7f7 !important;
   background: #464646 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #464646;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #464646;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #101010;
   color: #f7f7f7;
   border-color: #464646;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #464646;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #101010;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #f7f7f7;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #101010;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #464646;
   color: #f7f7f7;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #252525 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #252525 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #252525 rgba(16, 16, 16, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(16, 16, 16, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #252525;
   border-radius: 0px;
   border: 2px solid #101010;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #323232;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #101010;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #101010;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #101010;
   color: #f7f7f7;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #1d1d1d;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #2a2a2a;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-grayscale-dark.rstheme
+++ b/inst/themes/base16/base16-grayscale-dark.rstheme
@@ -18,26 +18,26 @@
   color: #f7f7f7;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #101010;
   color: #f7f7f7;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #101010;
   color: #f7f7f7;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #101010;
   color: #f7f7f7;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #f7f7f7;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #252525 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #ababab;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #464646 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f7f7f7;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #252525 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #464646 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #f7f7f7 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #464646 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #5e5e5e;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #464646 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #101010 !important;
   color: #f7f7f7 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #f7f7f7 !important;
   background: #464646 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #464646;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #464646;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #101010;
   color: #f7f7f7;
   border-color: #464646;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #464646;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #101010;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #f7f7f7;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #101010;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #464646;
   color: #f7f7f7;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #252525 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #252525 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #252525 rgba(16, 16, 16, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(16, 16, 16, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #252525;
   border-radius: 0px;
   border: 2px solid #101010;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #323232;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #101010;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #101010;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #101010;
   color: #f7f7f7;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #1d1d1d;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #2a2a2a;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-grayscale-light.rstheme
+++ b/inst/themes/base16/base16-grayscale-light.rstheme
@@ -18,35 +18,35 @@
   color: #101010;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #f7f7f7;
   color: #101010;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #f7f7f7;
   color: #101010;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #f7f7f7 !important;
   color: #101010 !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table {
+body .ace_editor_theme table {
   background-color: #f7f7f7 !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
+body .ace_editor_theme table thead > tr > th {
   background-color: #f7f7f7 !important;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme a {
+body.ace_editor_theme a {
   color: #101010 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-light-menus .gwt-Label {
+body .gwt-Label {
   color: #101010;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   background: #f7f7f7 !important;
   color: #101010 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
+body .rstudio-themes-default .rstudio-themes-background {
   background: #f7f7f7 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+body .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+body .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #f7f7f7;
   border-color: #f7f7f7;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
+body .rstudio-themes-default .rstudio-themes-border {
   border-color: #f7f7f7;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #b9b9b9 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #ababab;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-default .rstheme_center,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #e3e3e3 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #464646;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #b9b9b9 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #e3e3e3 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #101010 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
+body .search, body.rstudio-themes-default-menus .search {
   /* search */
   background: #e3e3e3 !important;
 }
 
-.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #5e5e5e;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
+.rstheme_secondaryToolbar, body .dataGridHeader {
   background: #e3e3e3 !important;
 }
 
 /* menu background */
-.rstudio-themes-light-menus .popupMiddleCenter,
-.rstudio-themes-light-menus .menuPopupMiddleCenter,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #f7f7f7 !important;
   color: #101010 !important;
 }
 
-.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #101010 !important;
   background: #b9b9b9 !important;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #b9b9b9;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #b9b9b9;
 }
 
-.rstudio-themes-light-menus .popupContent {
+body .popupContent {
   background: #f7f7f7;
   color: #101010;
   border-color: #b9b9b9;
 }
 
-.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #b9b9b9;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #f7f7f7;
   padding: 2px;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #101010;
   border: 0;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #f7f7f7;
 }
 
-.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #b9b9b9;
   color: #101010;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #b9b9b9 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #b9b9b9 !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-light-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
+body, body .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #e3e3e3 rgba(247, 247, 247, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(247, 247, 247, 0.5);
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #e3e3e3;
   border-radius: 0px;
   border: 2px solid #f7f7f7;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #d6d6d6;
 }
 
@@ -529,49 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #f7f7f7;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #f7f7f7;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #f7f7f7;
   color: #101010;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #eaeaea;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #dedede;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-grayscale-light.rstheme
+++ b/inst/themes/base16/base16-grayscale-light.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Grayscale Light {rsthemes} */
 /* Grayscale Light by Alexandre Gavioli (https://github.com/Alexx2/) */
@@ -18,35 +18,35 @@
   color: #101010;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-light-menus.ace_editor_theme {
   background-color: #f7f7f7;
   color: #101010;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #f7f7f7;
   color: #101010;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-light-menus .ace_editor_theme {
   background-color: #f7f7f7 !important;
   color: #101010 !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table {
+.rstudio-themes-light-menus .ace_editor_theme table {
   background-color: #f7f7f7 !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table thead > tr > th {
+.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
   background-color: #f7f7f7 !important;
 }
 
-.rstudio-themes-flat.ace_editor_theme a {
+.rstudio-themes-light-menus.ace_editor_theme a {
   color: #101010 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-light-menus .gwt-Label {
   color: #101010;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   background: #f7f7f7 !important;
   color: #101010 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
   background: #f7f7f7 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #f7f7f7;
   border-color: #f7f7f7;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
   border-color: #f7f7f7;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #b9b9b9 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #ababab;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-default .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #e3e3e3 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #464646;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #b9b9b9 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper {
   background: #e3e3e3 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
   color: #101010 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .search, .rstudio-themes-flat.rstudio-themes-default-menus .search {
+.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
   /* search */
   background: #e3e3e3 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #5e5e5e;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
   background: #e3e3e3 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-light-menus .popupMiddleCenter,
+.rstudio-themes-light-menus .menuPopupMiddleCenter,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter {
   background: #f7f7f7 !important;
   color: #101010 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #101010 !important;
   background: #b9b9b9 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-light-menus .themedPopupPanel {
   border: solid 1px #b9b9b9;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #b9b9b9;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-light-menus .popupContent {
   background: #f7f7f7;
   color: #101010;
   border-color: #b9b9b9;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #b9b9b9;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
   background: #f7f7f7;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
   background: #101010;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #f7f7f7;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #b9b9b9;
   color: #101010;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #b9b9b9 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #b9b9b9 !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-light-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #e3e3e3 rgba(247, 247, 247, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(247, 247, 247, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #e3e3e3;
   border-radius: 0px;
   border: 2px solid #f7f7f7;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #d6d6d6;
 }
 
@@ -529,35 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #f7f7f7;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #f7f7f7;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #f7f7f7;
   color: #101010;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #eaeaea;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #dedede;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-green-screen.rstheme
+++ b/inst/themes/base16/base16-green-screen.rstheme
@@ -18,26 +18,26 @@
   color: #00ff00;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #001100;
   color: #00ff00;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #001100;
   color: #00ff00;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #001100;
   color: #00ff00;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #00ff00;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #003300 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #009900;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #005500 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #00ff00;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #003300 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #005500 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #00ff00 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #005500 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #005500;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #005500 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #001100 !important;
   color: #00ff00 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #00ff00 !important;
   background: #005500 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #005500;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #005500;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #001100;
   color: #00ff00;
   border-color: #005500;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #005500;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #001100;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #00ff00;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #001100;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #005500;
   color: #00ff00;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #003300 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #003300 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #003300 rgba(0, 17, 0, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(0, 17, 0, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #003300;
   border-radius: 0px;
   border: 2px solid #001100;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #004d00;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #001100;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #001100;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #001100;
   color: #00ff00;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #002b00;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #004400;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-green-screen.rstheme
+++ b/inst/themes/base16/base16-green-screen.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Green Screen {rsthemes} */
 /* Green Screen by Chris Kempson (http://chriskempson.com) */
@@ -18,26 +18,26 @@
   color: #00ff00;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #001100;
   color: #00ff00;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #001100;
   color: #00ff00;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #001100;
   color: #00ff00;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #00ff00;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #003300 !important;
   color: #00ff00 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #003300 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #003300;
   border-color: #001100;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #001100;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #003300 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #009900;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #005500 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #00ff00;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #003300 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #005500 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #00ff00 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #005500 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #005500;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #005500 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #001100 !important;
   color: #00ff00 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #00ff00 !important;
   background: #005500 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #005500;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #005500;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #001100;
   color: #00ff00;
   border-color: #005500;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #005500;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #001100;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #00ff00;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #001100;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #005500;
   color: #00ff00;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #003300 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #003300 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #003300 rgba(0, 17, 0, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(0, 17, 0, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #003300;
   border-radius: 0px;
   border: 2px solid #001100;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #004d00;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #001100;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #001100;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #001100;
   color: #00ff00;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #002b00;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #004400;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-gruvbox-dark-hard.rstheme
+++ b/inst/themes/base16/base16-gruvbox-dark-hard.rstheme
@@ -18,26 +18,26 @@
   color: #fbf1c7;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #1d2021;
   color: #fbf1c7;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #1d2021;
   color: #fbf1c7;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #1d2021;
   color: #fbf1c7;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #fbf1c7;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #3c3836 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #bdae93;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #504945 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #fbf1c7;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #3c3836 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #504945 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #fbf1c7 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #504945 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d65d0e;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #504945 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #1d2021 !important;
   color: #fbf1c7 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #fbf1c7 !important;
   background: #504945 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #504945;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #504945;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #1d2021;
   color: #fbf1c7;
   border-color: #504945;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #504945;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #1d2021;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #fbf1c7;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1d2021;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #504945;
   color: #fbf1c7;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #3c3836 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #3c3836 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #3c3836 rgba(29, 32, 33, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(29, 32, 33, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #3c3836;
   border-radius: 0px;
   border: 2px solid #1d2021;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #494542;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #1d2021;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #1d2021;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1d2021;
   color: #fbf1c7;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #292d2f;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #353a3c;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-gruvbox-dark-hard.rstheme
+++ b/inst/themes/base16/base16-gruvbox-dark-hard.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Gruvbox dark, hard {rsthemes} */
 /* Gruvbox dark, hard by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox) */
@@ -18,26 +18,26 @@
   color: #fbf1c7;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #1d2021;
   color: #fbf1c7;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #1d2021;
   color: #fbf1c7;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #1d2021;
   color: #fbf1c7;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #fbf1c7;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #3c3836 !important;
   color: #fbf1c7 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #3c3836 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #3c3836;
   border-color: #1d2021;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #1d2021;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #3c3836 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #bdae93;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #504945 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #fbf1c7;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #3c3836 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #504945 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #fbf1c7 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #504945 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d65d0e;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #504945 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #1d2021 !important;
   color: #fbf1c7 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #fbf1c7 !important;
   background: #504945 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #504945;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #504945;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #1d2021;
   color: #fbf1c7;
   border-color: #504945;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #504945;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #1d2021;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #fbf1c7;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1d2021;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #504945;
   color: #fbf1c7;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #3c3836 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #3c3836 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #3c3836 rgba(29, 32, 33, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(29, 32, 33, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #3c3836;
   border-radius: 0px;
   border: 2px solid #1d2021;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #494542;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #1d2021;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #1d2021;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1d2021;
   color: #fbf1c7;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #292d2f;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #353a3c;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-gruvbox-dark-medium.rstheme
+++ b/inst/themes/base16/base16-gruvbox-dark-medium.rstheme
@@ -18,26 +18,26 @@
   color: #fbf1c7;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #282828;
   color: #fbf1c7;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #282828;
   color: #fbf1c7;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #282828;
   color: #fbf1c7;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #fbf1c7;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #3c3836 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #bdae93;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #504945 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #fbf1c7;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #3c3836 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #504945 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #fbf1c7 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #504945 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d65d0e;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #504945 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #282828 !important;
   color: #fbf1c7 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #fbf1c7 !important;
   background: #504945 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #504945;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #504945;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #282828;
   color: #fbf1c7;
   border-color: #504945;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #504945;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #282828;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #fbf1c7;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #282828;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #504945;
   color: #fbf1c7;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #3c3836 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #3c3836 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #3c3836 rgba(40, 40, 40, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(40, 40, 40, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #3c3836;
   border-radius: 0px;
   border: 2px solid #282828;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #494542;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #282828;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #282828;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #282828;
   color: #fbf1c7;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #353535;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #424242;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-gruvbox-dark-medium.rstheme
+++ b/inst/themes/base16/base16-gruvbox-dark-medium.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Gruvbox dark, medium {rsthemes} */
 /* Gruvbox dark, medium by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox) */
@@ -18,26 +18,26 @@
   color: #fbf1c7;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #282828;
   color: #fbf1c7;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #282828;
   color: #fbf1c7;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #282828;
   color: #fbf1c7;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #fbf1c7;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #3c3836 !important;
   color: #fbf1c7 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #3c3836 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #3c3836;
   border-color: #282828;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #282828;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #3c3836 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #bdae93;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #504945 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #fbf1c7;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #3c3836 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #504945 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #fbf1c7 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #504945 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d65d0e;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #504945 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #282828 !important;
   color: #fbf1c7 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #fbf1c7 !important;
   background: #504945 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #504945;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #504945;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #282828;
   color: #fbf1c7;
   border-color: #504945;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #504945;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #282828;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #fbf1c7;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #282828;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #504945;
   color: #fbf1c7;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #3c3836 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #3c3836 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #3c3836 rgba(40, 40, 40, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(40, 40, 40, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #3c3836;
   border-radius: 0px;
   border: 2px solid #282828;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #494542;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #282828;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #282828;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #282828;
   color: #fbf1c7;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #353535;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #424242;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-gruvbox-dark-pale.rstheme
+++ b/inst/themes/base16/base16-gruvbox-dark-pale.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Gruvbox dark, pale {rsthemes} */
 /* Gruvbox dark, pale by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox) */
@@ -18,26 +18,26 @@
   color: #ebdbb2;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #262626;
   color: #ebdbb2;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #262626;
   color: #ebdbb2;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #262626;
   color: #ebdbb2;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #ebdbb2;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #3a3a3a !important;
   color: #ebdbb2 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #3a3a3a !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #3a3a3a;
   border-color: #262626;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #262626;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #3a3a3a !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #949494;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #4e4e4e !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ebdbb2;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #3a3a3a !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #4e4e4e !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #ebdbb2 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #4e4e4e !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d65d0e;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #4e4e4e !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #262626 !important;
   color: #ebdbb2 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #ebdbb2 !important;
   background: #4e4e4e !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #4e4e4e;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #4e4e4e;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #262626;
   color: #ebdbb2;
   border-color: #4e4e4e;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #4e4e4e;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #262626;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #ebdbb2;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #262626;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #4e4e4e;
   color: #ebdbb2;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #3a3a3a !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #3a3a3a !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #3a3a3a rgba(38, 38, 38, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(38, 38, 38, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #3a3a3a;
   border-radius: 0px;
   border: 2px solid #262626;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #474747;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #262626;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #262626;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #262626;
   color: #ebdbb2;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #333333;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #404040;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-gruvbox-dark-pale.rstheme
+++ b/inst/themes/base16/base16-gruvbox-dark-pale.rstheme
@@ -18,26 +18,26 @@
   color: #ebdbb2;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #262626;
   color: #ebdbb2;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #262626;
   color: #ebdbb2;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #262626;
   color: #ebdbb2;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #ebdbb2;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #3a3a3a !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #949494;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #4e4e4e !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ebdbb2;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #3a3a3a !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #4e4e4e !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #ebdbb2 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #4e4e4e !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d65d0e;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #4e4e4e !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #262626 !important;
   color: #ebdbb2 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #ebdbb2 !important;
   background: #4e4e4e !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #4e4e4e;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #4e4e4e;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #262626;
   color: #ebdbb2;
   border-color: #4e4e4e;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #4e4e4e;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #262626;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #ebdbb2;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #262626;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #4e4e4e;
   color: #ebdbb2;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #3a3a3a !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #3a3a3a !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #3a3a3a rgba(38, 38, 38, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(38, 38, 38, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #3a3a3a;
   border-radius: 0px;
   border: 2px solid #262626;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #474747;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #262626;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #262626;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #262626;
   color: #ebdbb2;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #333333;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #404040;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-gruvbox-dark-soft.rstheme
+++ b/inst/themes/base16/base16-gruvbox-dark-soft.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Gruvbox dark, soft {rsthemes} */
 /* Gruvbox dark, soft by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox) */
@@ -18,26 +18,26 @@
   color: #fbf1c7;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #32302f;
   color: #fbf1c7;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #32302f;
   color: #fbf1c7;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #32302f;
   color: #fbf1c7;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #fbf1c7;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #3c3836 !important;
   color: #fbf1c7 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #3c3836 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #3c3836;
   border-color: #32302f;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #32302f;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #3c3836 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #bdae93;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #504945 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #fbf1c7;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #3c3836 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #504945 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #fbf1c7 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #504945 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d65d0e;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #504945 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #32302f !important;
   color: #fbf1c7 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #fbf1c7 !important;
   background: #504945 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #504945;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #504945;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #32302f;
   color: #fbf1c7;
   border-color: #504945;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #504945;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #32302f;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #fbf1c7;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #32302f;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #504945;
   color: #fbf1c7;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #3c3836 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #3c3836 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #3c3836 rgba(50, 48, 47, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(50, 48, 47, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #3c3836;
   border-radius: 0px;
   border: 2px solid #32302f;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #494542;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #32302f;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #32302f;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #32302f;
   color: #fbf1c7;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #3f3d3b;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #4c4948;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-gruvbox-dark-soft.rstheme
+++ b/inst/themes/base16/base16-gruvbox-dark-soft.rstheme
@@ -18,26 +18,26 @@
   color: #fbf1c7;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #32302f;
   color: #fbf1c7;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #32302f;
   color: #fbf1c7;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #32302f;
   color: #fbf1c7;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #fbf1c7;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #3c3836 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #bdae93;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #504945 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #fbf1c7;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #3c3836 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #504945 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #fbf1c7 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #504945 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d65d0e;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #504945 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #32302f !important;
   color: #fbf1c7 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #fbf1c7 !important;
   background: #504945 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #504945;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #504945;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #32302f;
   color: #fbf1c7;
   border-color: #504945;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #504945;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #32302f;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #fbf1c7;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #32302f;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #504945;
   color: #fbf1c7;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #3c3836 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #3c3836 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #3c3836 rgba(50, 48, 47, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(50, 48, 47, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #3c3836;
   border-radius: 0px;
   border: 2px solid #32302f;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #494542;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #32302f;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #32302f;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #32302f;
   color: #fbf1c7;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #3f3d3b;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #4c4948;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-gruvbox-light-hard.rstheme
+++ b/inst/themes/base16/base16-gruvbox-light-hard.rstheme
@@ -18,35 +18,35 @@
   color: #282828;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #f9f5d7;
   color: #282828;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #f9f5d7;
   color: #282828;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #f9f5d7 !important;
   color: #282828 !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table {
+body .ace_editor_theme table {
   background-color: #f9f5d7 !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
+body .ace_editor_theme table thead > tr > th {
   background-color: #f9f5d7 !important;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme a {
+body.ace_editor_theme a {
   color: #282828 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-light-menus .gwt-Label {
+body .gwt-Label {
   color: #282828;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   background: #f9f5d7 !important;
   color: #282828 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
+body .rstudio-themes-default .rstudio-themes-background {
   background: #f9f5d7 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+body .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+body .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #f9f5d7;
   border-color: #f9f5d7;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
+body .rstudio-themes-default .rstudio-themes-border {
   border-color: #f9f5d7;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #d5c4a1 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #bdae93;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-default .rstheme_center,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #ebdbb2 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #504945;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #d5c4a1 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #ebdbb2 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #282828 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
+body .search, body.rstudio-themes-default-menus .search {
   /* search */
   background: #ebdbb2 !important;
 }
 
-.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d65d0e;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
+.rstheme_secondaryToolbar, body .dataGridHeader {
   background: #ebdbb2 !important;
 }
 
 /* menu background */
-.rstudio-themes-light-menus .popupMiddleCenter,
-.rstudio-themes-light-menus .menuPopupMiddleCenter,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #f9f5d7 !important;
   color: #282828 !important;
 }
 
-.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #282828 !important;
   background: #d5c4a1 !important;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #d5c4a1;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #d5c4a1;
 }
 
-.rstudio-themes-light-menus .popupContent {
+body .popupContent {
   background: #f9f5d7;
   color: #282828;
   border-color: #d5c4a1;
 }
 
-.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #d5c4a1;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #f9f5d7;
   padding: 2px;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #282828;
   border: 0;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #f9f5d7;
 }
 
-.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #d5c4a1;
   color: #282828;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #d5c4a1 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #d5c4a1 !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-light-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
+body, body .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #ebdbb2 rgba(249, 245, 215, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(249, 245, 215, 0.5);
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #ebdbb2;
   border-radius: 0px;
   border: 2px solid #f9f5d7;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #e6d29e;
 }
 
@@ -529,49 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #f9f5d7;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #f9f5d7;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #f9f5d7;
   color: #282828;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #f6efc1;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #f2eaab;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-gruvbox-light-hard.rstheme
+++ b/inst/themes/base16/base16-gruvbox-light-hard.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Gruvbox light, hard {rsthemes} */
 /* Gruvbox light, hard by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox) */
@@ -18,35 +18,35 @@
   color: #282828;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-light-menus.ace_editor_theme {
   background-color: #f9f5d7;
   color: #282828;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #f9f5d7;
   color: #282828;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-light-menus .ace_editor_theme {
   background-color: #f9f5d7 !important;
   color: #282828 !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table {
+.rstudio-themes-light-menus .ace_editor_theme table {
   background-color: #f9f5d7 !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table thead > tr > th {
+.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
   background-color: #f9f5d7 !important;
 }
 
-.rstudio-themes-flat.ace_editor_theme a {
+.rstudio-themes-light-menus.ace_editor_theme a {
   color: #282828 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-light-menus .gwt-Label {
   color: #282828;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   background: #f9f5d7 !important;
   color: #282828 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
   background: #f9f5d7 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #f9f5d7;
   border-color: #f9f5d7;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
   border-color: #f9f5d7;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #d5c4a1 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #bdae93;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-default .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #ebdbb2 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #504945;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #d5c4a1 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper {
   background: #ebdbb2 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
   color: #282828 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .search, .rstudio-themes-flat.rstudio-themes-default-menus .search {
+.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
   /* search */
   background: #ebdbb2 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d65d0e;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
   background: #ebdbb2 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-light-menus .popupMiddleCenter,
+.rstudio-themes-light-menus .menuPopupMiddleCenter,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter {
   background: #f9f5d7 !important;
   color: #282828 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #282828 !important;
   background: #d5c4a1 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-light-menus .themedPopupPanel {
   border: solid 1px #d5c4a1;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #d5c4a1;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-light-menus .popupContent {
   background: #f9f5d7;
   color: #282828;
   border-color: #d5c4a1;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #d5c4a1;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
   background: #f9f5d7;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
   background: #282828;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #f9f5d7;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #d5c4a1;
   color: #282828;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #d5c4a1 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #d5c4a1 !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-light-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #ebdbb2 rgba(249, 245, 215, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(249, 245, 215, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #ebdbb2;
   border-radius: 0px;
   border: 2px solid #f9f5d7;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #e6d29e;
 }
 
@@ -529,35 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #f9f5d7;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #f9f5d7;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #f9f5d7;
   color: #282828;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #f6efc1;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #f2eaab;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-gruvbox-light-medium.rstheme
+++ b/inst/themes/base16/base16-gruvbox-light-medium.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Gruvbox light, medium {rsthemes} */
 /* Gruvbox light, medium by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox) */
@@ -18,35 +18,35 @@
   color: #282828;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-light-menus.ace_editor_theme {
   background-color: #fbf1c7;
   color: #282828;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #fbf1c7;
   color: #282828;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-light-menus .ace_editor_theme {
   background-color: #fbf1c7 !important;
   color: #282828 !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table {
+.rstudio-themes-light-menus .ace_editor_theme table {
   background-color: #fbf1c7 !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table thead > tr > th {
+.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
   background-color: #fbf1c7 !important;
 }
 
-.rstudio-themes-flat.ace_editor_theme a {
+.rstudio-themes-light-menus.ace_editor_theme a {
   color: #282828 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-light-menus .gwt-Label {
   color: #282828;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   background: #fbf1c7 !important;
   color: #282828 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
   background: #fbf1c7 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #fbf1c7;
   border-color: #fbf1c7;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
   border-color: #fbf1c7;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #d5c4a1 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #bdae93;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-default .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #ebdbb2 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #504945;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #d5c4a1 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper {
   background: #ebdbb2 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
   color: #282828 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .search, .rstudio-themes-flat.rstudio-themes-default-menus .search {
+.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
   /* search */
   background: #ebdbb2 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d65d0e;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
   background: #ebdbb2 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-light-menus .popupMiddleCenter,
+.rstudio-themes-light-menus .menuPopupMiddleCenter,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter {
   background: #fbf1c7 !important;
   color: #282828 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #282828 !important;
   background: #d5c4a1 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-light-menus .themedPopupPanel {
   border: solid 1px #d5c4a1;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #d5c4a1;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-light-menus .popupContent {
   background: #fbf1c7;
   color: #282828;
   border-color: #d5c4a1;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #d5c4a1;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
   background: #fbf1c7;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
   background: #282828;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #fbf1c7;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #d5c4a1;
   color: #282828;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #d5c4a1 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #d5c4a1 !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-light-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #ebdbb2 rgba(251, 241, 199, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(251, 241, 199, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #ebdbb2;
   border-radius: 0px;
   border: 2px solid #fbf1c7;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #e6d29e;
 }
 
@@ -529,35 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #fbf1c7;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #fbf1c7;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #fbf1c7;
   color: #282828;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #f9ebaf;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #f8e597;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-gruvbox-light-medium.rstheme
+++ b/inst/themes/base16/base16-gruvbox-light-medium.rstheme
@@ -18,35 +18,35 @@
   color: #282828;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #fbf1c7;
   color: #282828;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #fbf1c7;
   color: #282828;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #fbf1c7 !important;
   color: #282828 !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table {
+body .ace_editor_theme table {
   background-color: #fbf1c7 !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
+body .ace_editor_theme table thead > tr > th {
   background-color: #fbf1c7 !important;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme a {
+body.ace_editor_theme a {
   color: #282828 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-light-menus .gwt-Label {
+body .gwt-Label {
   color: #282828;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   background: #fbf1c7 !important;
   color: #282828 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
+body .rstudio-themes-default .rstudio-themes-background {
   background: #fbf1c7 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+body .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+body .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #fbf1c7;
   border-color: #fbf1c7;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
+body .rstudio-themes-default .rstudio-themes-border {
   border-color: #fbf1c7;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #d5c4a1 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #bdae93;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-default .rstheme_center,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #ebdbb2 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #504945;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #d5c4a1 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #ebdbb2 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #282828 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
+body .search, body.rstudio-themes-default-menus .search {
   /* search */
   background: #ebdbb2 !important;
 }
 
-.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d65d0e;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
+.rstheme_secondaryToolbar, body .dataGridHeader {
   background: #ebdbb2 !important;
 }
 
 /* menu background */
-.rstudio-themes-light-menus .popupMiddleCenter,
-.rstudio-themes-light-menus .menuPopupMiddleCenter,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #fbf1c7 !important;
   color: #282828 !important;
 }
 
-.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #282828 !important;
   background: #d5c4a1 !important;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #d5c4a1;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #d5c4a1;
 }
 
-.rstudio-themes-light-menus .popupContent {
+body .popupContent {
   background: #fbf1c7;
   color: #282828;
   border-color: #d5c4a1;
 }
 
-.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #d5c4a1;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #fbf1c7;
   padding: 2px;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #282828;
   border: 0;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #fbf1c7;
 }
 
-.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #d5c4a1;
   color: #282828;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #d5c4a1 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #d5c4a1 !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-light-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
+body, body .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #ebdbb2 rgba(251, 241, 199, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(251, 241, 199, 0.5);
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #ebdbb2;
   border-radius: 0px;
   border: 2px solid #fbf1c7;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #e6d29e;
 }
 
@@ -529,49 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #fbf1c7;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #fbf1c7;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #fbf1c7;
   color: #282828;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #f9ebaf;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #f8e597;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-gruvbox-light-soft.rstheme
+++ b/inst/themes/base16/base16-gruvbox-light-soft.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Gruvbox light, soft {rsthemes} */
 /* Gruvbox light, soft by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox) */
@@ -18,35 +18,35 @@
   color: #282828;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-light-menus.ace_editor_theme {
   background-color: #f2e5bc;
   color: #282828;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #f2e5bc;
   color: #282828;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-light-menus .ace_editor_theme {
   background-color: #f2e5bc !important;
   color: #282828 !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table {
+.rstudio-themes-light-menus .ace_editor_theme table {
   background-color: #f2e5bc !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table thead > tr > th {
+.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
   background-color: #f2e5bc !important;
 }
 
-.rstudio-themes-flat.ace_editor_theme a {
+.rstudio-themes-light-menus.ace_editor_theme a {
   color: #282828 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-light-menus .gwt-Label {
   color: #282828;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   background: #f2e5bc !important;
   color: #282828 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
   background: #f2e5bc !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #f2e5bc;
   border-color: #f2e5bc;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
   border-color: #f2e5bc;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #d5c4a1 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #bdae93;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-default .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #ebdbb2 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #504945;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #d5c4a1 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper {
   background: #ebdbb2 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
   color: #282828 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .search, .rstudio-themes-flat.rstudio-themes-default-menus .search {
+.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
   /* search */
   background: #ebdbb2 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d65d0e;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
   background: #ebdbb2 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-light-menus .popupMiddleCenter,
+.rstudio-themes-light-menus .menuPopupMiddleCenter,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter {
   background: #f2e5bc !important;
   color: #282828 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #282828 !important;
   background: #d5c4a1 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-light-menus .themedPopupPanel {
   border: solid 1px #d5c4a1;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #d5c4a1;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-light-menus .popupContent {
   background: #f2e5bc;
   color: #282828;
   border-color: #d5c4a1;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #d5c4a1;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
   background: #f2e5bc;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
   background: #282828;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #f2e5bc;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #d5c4a1;
   color: #282828;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #d5c4a1 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #d5c4a1 !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-light-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #ebdbb2 rgba(242, 229, 188, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(242, 229, 188, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #ebdbb2;
   border-radius: 0px;
   border: 2px solid #f2e5bc;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #e6d29e;
 }
 
@@ -529,35 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #f2e5bc;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #f2e5bc;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #f2e5bc;
   color: #282828;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #eedda7;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #ead491;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-gruvbox-light-soft.rstheme
+++ b/inst/themes/base16/base16-gruvbox-light-soft.rstheme
@@ -18,35 +18,35 @@
   color: #282828;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #f2e5bc;
   color: #282828;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #f2e5bc;
   color: #282828;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #f2e5bc !important;
   color: #282828 !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table {
+body .ace_editor_theme table {
   background-color: #f2e5bc !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
+body .ace_editor_theme table thead > tr > th {
   background-color: #f2e5bc !important;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme a {
+body.ace_editor_theme a {
   color: #282828 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-light-menus .gwt-Label {
+body .gwt-Label {
   color: #282828;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   background: #f2e5bc !important;
   color: #282828 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
+body .rstudio-themes-default .rstudio-themes-background {
   background: #f2e5bc !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+body .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+body .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #f2e5bc;
   border-color: #f2e5bc;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
+body .rstudio-themes-default .rstudio-themes-border {
   border-color: #f2e5bc;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #d5c4a1 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #bdae93;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-default .rstheme_center,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #ebdbb2 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #504945;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #d5c4a1 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #ebdbb2 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #282828 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
+body .search, body.rstudio-themes-default-menus .search {
   /* search */
   background: #ebdbb2 !important;
 }
 
-.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d65d0e;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
+.rstheme_secondaryToolbar, body .dataGridHeader {
   background: #ebdbb2 !important;
 }
 
 /* menu background */
-.rstudio-themes-light-menus .popupMiddleCenter,
-.rstudio-themes-light-menus .menuPopupMiddleCenter,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #f2e5bc !important;
   color: #282828 !important;
 }
 
-.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #282828 !important;
   background: #d5c4a1 !important;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #d5c4a1;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #d5c4a1;
 }
 
-.rstudio-themes-light-menus .popupContent {
+body .popupContent {
   background: #f2e5bc;
   color: #282828;
   border-color: #d5c4a1;
 }
 
-.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #d5c4a1;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #f2e5bc;
   padding: 2px;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #282828;
   border: 0;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #f2e5bc;
 }
 
-.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #d5c4a1;
   color: #282828;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #d5c4a1 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #d5c4a1 !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-light-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
+body, body .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #ebdbb2 rgba(242, 229, 188, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(242, 229, 188, 0.5);
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #ebdbb2;
   border-radius: 0px;
   border: 2px solid #f2e5bc;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #e6d29e;
 }
 
@@ -529,49 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #f2e5bc;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #f2e5bc;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #f2e5bc;
   color: #282828;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #eedda7;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #ead491;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-harmonic16-dark.rstheme
+++ b/inst/themes/base16/base16-harmonic16-dark.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Harmonic16 Dark {rsthemes} */
 /* Harmonic16 Dark by Jannik Siebert (https://github.com/janniks) */
@@ -18,26 +18,26 @@
   color: #f7f9fb;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #0b1c2c;
   color: #f7f9fb;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #0b1c2c;
   color: #f7f9fb;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #0b1c2c;
   color: #f7f9fb;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #f7f9fb;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #223b54 !important;
   color: #f7f9fb !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #223b54 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #223b54;
   border-color: #0b1c2c;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #0b1c2c;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #223b54 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #aabcce;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #405c79 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f7f9fb;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #223b54 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #405c79 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #f7f9fb !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #405c79 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #bf5656;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #405c79 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #0b1c2c !important;
   color: #f7f9fb !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #f7f9fb !important;
   background: #405c79 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #405c79;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #405c79;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #0b1c2c;
   color: #f7f9fb;
   border-color: #405c79;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #405c79;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #0b1c2c;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #f7f9fb;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #0b1c2c;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #405c79;
   color: #f7f9fb;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #223b54 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #223b54 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #223b54 rgba(11, 28, 44, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(11, 28, 44, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #223b54;
   border-radius: 0px;
   border: 2px solid #0b1c2c;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #294866;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #0b1c2c;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #0b1c2c;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #0b1c2c;
   color: #f7f9fb;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #102940;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #153655;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-harmonic16-dark.rstheme
+++ b/inst/themes/base16/base16-harmonic16-dark.rstheme
@@ -18,26 +18,26 @@
   color: #f7f9fb;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #0b1c2c;
   color: #f7f9fb;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #0b1c2c;
   color: #f7f9fb;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #0b1c2c;
   color: #f7f9fb;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #f7f9fb;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #223b54 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #aabcce;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #405c79 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f7f9fb;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #223b54 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #405c79 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #f7f9fb !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #405c79 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #bf5656;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #405c79 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #0b1c2c !important;
   color: #f7f9fb !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #f7f9fb !important;
   background: #405c79 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #405c79;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #405c79;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #0b1c2c;
   color: #f7f9fb;
   border-color: #405c79;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #405c79;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #0b1c2c;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #f7f9fb;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #0b1c2c;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #405c79;
   color: #f7f9fb;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #223b54 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #223b54 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #223b54 rgba(11, 28, 44, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(11, 28, 44, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #223b54;
   border-radius: 0px;
   border: 2px solid #0b1c2c;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #294866;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #0b1c2c;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #0b1c2c;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #0b1c2c;
   color: #f7f9fb;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #102940;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #153655;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-harmonic16-light.rstheme
+++ b/inst/themes/base16/base16-harmonic16-light.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Harmonic16 Light {rsthemes} */
 /* Harmonic16 Light by Jannik Siebert (https://github.com/janniks) */
@@ -18,35 +18,35 @@
   color: #0b1c2c;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-light-menus.ace_editor_theme {
   background-color: #f7f9fb;
   color: #0b1c2c;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #f7f9fb;
   color: #0b1c2c;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-light-menus .ace_editor_theme {
   background-color: #f7f9fb !important;
   color: #0b1c2c !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table {
+.rstudio-themes-light-menus .ace_editor_theme table {
   background-color: #f7f9fb !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table thead > tr > th {
+.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
   background-color: #f7f9fb !important;
 }
 
-.rstudio-themes-flat.ace_editor_theme a {
+.rstudio-themes-light-menus.ace_editor_theme a {
   color: #0b1c2c !important;
   font-weight: bold;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-light-menus .gwt-Label {
   color: #0b1c2c;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   background: #f7f9fb !important;
   color: #0b1c2c !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
   background: #f7f9fb !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #f7f9fb;
   border-color: #f7f9fb;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
   border-color: #f7f9fb;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #cbd6e2 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #aabcce;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-default .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #e5ebf1 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #405c79;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #cbd6e2 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper {
   background: #e5ebf1 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
   color: #0b1c2c !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .search, .rstudio-themes-flat.rstudio-themes-default-menus .search {
+.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
   /* search */
   background: #e5ebf1 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #bf5656;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
   background: #e5ebf1 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-light-menus .popupMiddleCenter,
+.rstudio-themes-light-menus .menuPopupMiddleCenter,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter {
   background: #f7f9fb !important;
   color: #0b1c2c !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #0b1c2c !important;
   background: #cbd6e2 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-light-menus .themedPopupPanel {
   border: solid 1px #cbd6e2;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #cbd6e2;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-light-menus .popupContent {
   background: #f7f9fb;
   color: #0b1c2c;
   border-color: #cbd6e2;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #cbd6e2;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
   background: #f7f9fb;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
   background: #0b1c2c;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #f7f9fb;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #cbd6e2;
   color: #0b1c2c;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #cbd6e2 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #cbd6e2 !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-light-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #e5ebf1 rgba(247, 249, 251, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(247, 249, 251, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #e5ebf1;
   border-radius: 0px;
   border: 2px solid #f7f9fb;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #d4dee8;
 }
 
@@ -529,35 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #f7f9fb;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #f7f9fb;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #f7f9fb;
   color: #0b1c2c;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #e6ecf3;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #d5e0ea;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-harmonic16-light.rstheme
+++ b/inst/themes/base16/base16-harmonic16-light.rstheme
@@ -18,35 +18,35 @@
   color: #0b1c2c;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #f7f9fb;
   color: #0b1c2c;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #f7f9fb;
   color: #0b1c2c;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #f7f9fb !important;
   color: #0b1c2c !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table {
+body .ace_editor_theme table {
   background-color: #f7f9fb !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
+body .ace_editor_theme table thead > tr > th {
   background-color: #f7f9fb !important;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme a {
+body.ace_editor_theme a {
   color: #0b1c2c !important;
   font-weight: bold;
 }
 
-.rstudio-themes-light-menus .gwt-Label {
+body .gwt-Label {
   color: #0b1c2c;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   background: #f7f9fb !important;
   color: #0b1c2c !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
+body .rstudio-themes-default .rstudio-themes-background {
   background: #f7f9fb !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+body .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+body .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #f7f9fb;
   border-color: #f7f9fb;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
+body .rstudio-themes-default .rstudio-themes-border {
   border-color: #f7f9fb;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #cbd6e2 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #aabcce;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-default .rstheme_center,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #e5ebf1 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #405c79;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #cbd6e2 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #e5ebf1 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #0b1c2c !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
+body .search, body.rstudio-themes-default-menus .search {
   /* search */
   background: #e5ebf1 !important;
 }
 
-.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #bf5656;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
+.rstheme_secondaryToolbar, body .dataGridHeader {
   background: #e5ebf1 !important;
 }
 
 /* menu background */
-.rstudio-themes-light-menus .popupMiddleCenter,
-.rstudio-themes-light-menus .menuPopupMiddleCenter,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #f7f9fb !important;
   color: #0b1c2c !important;
 }
 
-.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #0b1c2c !important;
   background: #cbd6e2 !important;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #cbd6e2;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #cbd6e2;
 }
 
-.rstudio-themes-light-menus .popupContent {
+body .popupContent {
   background: #f7f9fb;
   color: #0b1c2c;
   border-color: #cbd6e2;
 }
 
-.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #cbd6e2;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #f7f9fb;
   padding: 2px;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #0b1c2c;
   border: 0;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #f7f9fb;
 }
 
-.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #cbd6e2;
   color: #0b1c2c;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #cbd6e2 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #cbd6e2 !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-light-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
+body, body .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #e5ebf1 rgba(247, 249, 251, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(247, 249, 251, 0.5);
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #e5ebf1;
   border-radius: 0px;
   border: 2px solid #f7f9fb;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #d4dee8;
 }
 
@@ -529,49 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #f7f9fb;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #f7f9fb;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #f7f9fb;
   color: #0b1c2c;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #e6ecf3;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #d5e0ea;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-hopscotch.rstheme
+++ b/inst/themes/base16/base16-hopscotch.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Hopscotch {rsthemes} */
 /* Hopscotch by Jan T. Sott */
@@ -18,26 +18,26 @@
   color: #ffffff;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #322931;
   color: #ffffff;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #322931;
   color: #ffffff;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #322931;
   color: #ffffff;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #ffffff;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #433b42 !important;
   color: #ffffff !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #433b42 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #433b42;
   border-color: #322931;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #322931;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #433b42 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #989498;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #5c545b !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #433b42 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #5c545b !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #5c545b !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #b33508;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #5c545b !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #322931 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #ffffff !important;
   background: #5c545b !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #5c545b;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #5c545b;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #322931;
   color: #ffffff;
   border-color: #5c545b;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #5c545b;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #322931;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #ffffff;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #322931;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #5c545b;
   color: #ffffff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #433b42 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #433b42 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #433b42 rgba(50, 41, 49, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(50, 41, 49, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #433b42;
   border-radius: 0px;
   border: 2px solid #322931;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #51474f;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #322931;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #322931;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #322931;
   color: #ffffff;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #40343f;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #4e404c;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-hopscotch.rstheme
+++ b/inst/themes/base16/base16-hopscotch.rstheme
@@ -18,26 +18,26 @@
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #322931;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #322931;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #322931;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #ffffff;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #433b42 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #989498;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #5c545b !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #433b42 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #5c545b !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #ffffff !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #5c545b !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #b33508;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #5c545b !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #322931 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #ffffff !important;
   background: #5c545b !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #5c545b;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #5c545b;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #322931;
   color: #ffffff;
   border-color: #5c545b;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #5c545b;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #322931;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #ffffff;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #322931;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #5c545b;
   color: #ffffff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #433b42 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #433b42 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #433b42 rgba(50, 41, 49, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(50, 41, 49, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #433b42;
   border-radius: 0px;
   border: 2px solid #322931;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #51474f;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #322931;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #322931;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #322931;
   color: #ffffff;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #40343f;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #4e404c;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-ir-black.rstheme
+++ b/inst/themes/base16/base16-ir-black.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 @charset "UTF-8";
 /* rs-theme-name: base16 IR Black {rsthemes} */
@@ -19,26 +19,26 @@
   color: #fdfbee;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #000000;
   color: #fdfbee;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #000000;
   color: #fdfbee;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #000000;
   color: #fdfbee;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #fdfbee;
 }
 
@@ -273,134 +273,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #242422 !important;
   color: #fdfbee !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #242422 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #242422;
   border-color: #000000;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #000000;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #242422 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #918f88;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #484844 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #fdfbee;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #242422 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #484844 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #fdfbee !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #484844 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #b18a3d;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #484844 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #000000 !important;
   color: #fdfbee !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #fdfbee !important;
   background: #484844 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #484844;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #484844;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #000000;
   color: #fdfbee;
   border-color: #484844;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #484844;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #000000;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #fdfbee;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #000000;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #484844;
   color: #fdfbee;
 }
@@ -414,15 +414,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #242422 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #242422 !important;
 }
 
@@ -444,37 +444,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #242422 rgba(0, 0, 0, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(0, 0, 0, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #242422;
   border-radius: 0px;
   border: 2px solid #000000;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #31312e;
 }
 
@@ -500,35 +500,49 @@ input#rstudio_command_palette_search {
   border-color: #000000;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #000000;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #000000;
   color: #fdfbee;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #0d0d0d;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #1a1a1a;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-ir-black.rstheme
+++ b/inst/themes/base16/base16-ir-black.rstheme
@@ -19,26 +19,26 @@
   color: #fdfbee;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #000000;
   color: #fdfbee;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #000000;
   color: #fdfbee;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #000000;
   color: #fdfbee;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #fdfbee;
 }
 
@@ -295,112 +295,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #242422 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #918f88;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #484844 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #fdfbee;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #242422 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #484844 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #fdfbee !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #484844 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #b18a3d;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #484844 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #000000 !important;
   color: #fdfbee !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #fdfbee !important;
   background: #484844 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #484844;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #484844;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #000000;
   color: #fdfbee;
   border-color: #484844;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #484844;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #000000;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #fdfbee;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #000000;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #484844;
   color: #fdfbee;
 }
@@ -414,15 +414,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #242422 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #242422 !important;
 }
 
@@ -444,37 +444,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #242422 rgba(0, 0, 0, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(0, 0, 0, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #242422;
   border-radius: 0px;
   border: 2px solid #000000;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #31312e;
 }
 
@@ -500,49 +500,49 @@ input#rstudio_command_palette_search {
   border-color: #000000;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #000000;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #000000;
   color: #fdfbee;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #0d0d0d;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #1a1a1a;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-isotope.rstheme
+++ b/inst/themes/base16/base16-isotope.rstheme
@@ -18,26 +18,26 @@
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #ffffff;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #404040 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #c0c0c0;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #606060 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #404040 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #606060 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #ffffff !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #606060 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #3300ff;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #606060 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #000000 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #ffffff !important;
   background: #606060 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #606060;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #606060;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #000000;
   color: #ffffff;
   border-color: #606060;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #606060;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #000000;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #ffffff;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #000000;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #606060;
   color: #ffffff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #404040 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #404040 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #404040 rgba(0, 0, 0, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(0, 0, 0, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #404040;
   border-radius: 0px;
   border: 2px solid #000000;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #4d4d4d;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #000000;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #000000;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #0d0d0d;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #1a1a1a;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-isotope.rstheme
+++ b/inst/themes/base16/base16-isotope.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Isotope {rsthemes} */
 /* Isotope by Jan T. Sott */
@@ -18,26 +18,26 @@
   color: #ffffff;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #ffffff;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #404040 !important;
   color: #ffffff !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #404040 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #404040;
   border-color: #000000;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #000000;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #404040 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #c0c0c0;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #606060 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #404040 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #606060 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #606060 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #3300ff;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #606060 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #000000 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #ffffff !important;
   background: #606060 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #606060;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #606060;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #000000;
   color: #ffffff;
   border-color: #606060;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #606060;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #000000;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #ffffff;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #000000;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #606060;
   color: #ffffff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #404040 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #404040 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #404040 rgba(0, 0, 0, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(0, 0, 0, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #404040;
   border-radius: 0px;
   border: 2px solid #000000;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #4d4d4d;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #000000;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #000000;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #0d0d0d;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #1a1a1a;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-london-tube.rstheme
+++ b/inst/themes/base16/base16-london-tube.rstheme
@@ -18,26 +18,26 @@
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #231f20;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #231f20;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #231f20;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #ffffff;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #1c3f95 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #959ca1;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #5a5758 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #1c3f95 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #5a5758 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #ffffff !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #5a5758 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #b06110;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #5a5758 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #231f20 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #ffffff !important;
   background: #5a5758 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #5a5758;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #5a5758;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #231f20;
   color: #ffffff;
   border-color: #5a5758;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #5a5758;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #231f20;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #ffffff;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #231f20;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #5a5758;
   color: #ffffff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #1c3f95 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #1c3f95 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #1c3f95 rgba(35, 31, 32, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(35, 31, 32, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #1c3f95;
   border-radius: 0px;
   border: 2px solid #231f20;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #2048aa;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #231f20;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #231f20;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #231f20;
   color: #ffffff;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #312b2c;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3e3739;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-london-tube.rstheme
+++ b/inst/themes/base16/base16-london-tube.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 London Tube {rsthemes} */
 /* London Tube by Jan T. Sott */
@@ -18,26 +18,26 @@
   color: #ffffff;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #231f20;
   color: #ffffff;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #231f20;
   color: #ffffff;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #231f20;
   color: #ffffff;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #ffffff;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #1c3f95 !important;
   color: #ffffff !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #1c3f95 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #1c3f95;
   border-color: #231f20;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #231f20;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #1c3f95 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #959ca1;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #5a5758 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #1c3f95 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #5a5758 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #5a5758 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #b06110;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #5a5758 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #231f20 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #ffffff !important;
   background: #5a5758 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #5a5758;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #5a5758;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #231f20;
   color: #ffffff;
   border-color: #5a5758;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #5a5758;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #231f20;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #ffffff;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #231f20;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #5a5758;
   color: #ffffff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #1c3f95 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #1c3f95 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #1c3f95 rgba(35, 31, 32, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(35, 31, 32, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #1c3f95;
   border-radius: 0px;
   border: 2px solid #231f20;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #2048aa;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #231f20;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #231f20;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #231f20;
   color: #ffffff;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #312b2c;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3e3739;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-macintosh.rstheme
+++ b/inst/themes/base16/base16-macintosh.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Macintosh {rsthemes} */
 /* Macintosh by Rebecca Bettencourt (http://www.kreativekorp.com) */
@@ -18,26 +18,26 @@
   color: #ffffff;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #ffffff;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #404040 !important;
   color: #ffffff !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #404040 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #404040;
   border-color: #000000;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #000000;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #404040 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #808080;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #404040 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #404040 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #404040 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #404040 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #90713a;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #404040 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #000000 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #ffffff !important;
   background: #404040 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #404040;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #404040;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #000000;
   color: #ffffff;
   border-color: #404040;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #404040;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #000000;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #ffffff;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #000000;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #404040;
   color: #ffffff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #404040 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #404040 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #404040 rgba(0, 0, 0, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(0, 0, 0, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #404040;
   border-radius: 0px;
   border: 2px solid #000000;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #4d4d4d;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #000000;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #000000;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #0d0d0d;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #1a1a1a;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-macintosh.rstheme
+++ b/inst/themes/base16/base16-macintosh.rstheme
@@ -18,26 +18,26 @@
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #ffffff;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #404040 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #808080;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #404040 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #404040 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #404040 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #ffffff !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #404040 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #90713a;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #404040 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #000000 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #ffffff !important;
   background: #404040 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #404040;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #404040;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #000000;
   color: #ffffff;
   border-color: #404040;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #404040;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #000000;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #ffffff;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #000000;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #404040;
   color: #ffffff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #404040 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #404040 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #404040 rgba(0, 0, 0, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(0, 0, 0, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #404040;
   border-radius: 0px;
   border: 2px solid #000000;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #4d4d4d;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #000000;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #000000;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #0d0d0d;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #1a1a1a;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-marrakesh.rstheme
+++ b/inst/themes/base16/base16-marrakesh.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Marrakesh {rsthemes} */
 /* Marrakesh by Alexandre Gavioli (http://github.com/Alexx2/) */
@@ -18,26 +18,26 @@
   color: #faf0a5;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #201602;
   color: #faf0a5;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #201602;
   color: #faf0a5;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #201602;
   color: #faf0a5;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #faf0a5;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #302e00 !important;
   color: #faf0a5 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #302e00 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #302e00;
   border-color: #201602;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #201602;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #302e00 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #86813b;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #5f5b17 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #faf0a5;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #302e00 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #5f5b17 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #faf0a5 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #5f5b17 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #b3588e;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #5f5b17 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #201602 !important;
   color: #faf0a5 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #faf0a5 !important;
   background: #5f5b17 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #5f5b17;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #5f5b17;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #201602;
   color: #faf0a5;
   border-color: #5f5b17;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #5f5b17;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #201602;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #faf0a5;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #201602;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #5f5b17;
   color: #faf0a5;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #302e00 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #302e00 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #302e00 rgba(32, 22, 2, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(32, 22, 2, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #302e00;
   border-radius: 0px;
   border: 2px solid #201602;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #4a4600;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #201602;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #201602;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #201602;
   color: #faf0a5;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #382704;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #503705;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-marrakesh.rstheme
+++ b/inst/themes/base16/base16-marrakesh.rstheme
@@ -18,26 +18,26 @@
   color: #faf0a5;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #201602;
   color: #faf0a5;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #201602;
   color: #faf0a5;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #201602;
   color: #faf0a5;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #faf0a5;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #302e00 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #86813b;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #5f5b17 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #faf0a5;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #302e00 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #5f5b17 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #faf0a5 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #5f5b17 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #b3588e;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #5f5b17 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #201602 !important;
   color: #faf0a5 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #faf0a5 !important;
   background: #5f5b17 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #5f5b17;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #5f5b17;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #201602;
   color: #faf0a5;
   border-color: #5f5b17;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #5f5b17;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #201602;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #faf0a5;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #201602;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #5f5b17;
   color: #faf0a5;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #302e00 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #302e00 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #302e00 rgba(32, 22, 2, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(32, 22, 2, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #302e00;
   border-radius: 0px;
   border: 2px solid #201602;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #4a4600;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #201602;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #201602;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #201602;
   color: #faf0a5;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #382704;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #503705;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-materia.rstheme
+++ b/inst/themes/base16/base16-materia.rstheme
@@ -18,26 +18,26 @@
   color: #FFFFFF;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #263238;
   color: #FFFFFF;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #263238;
   color: #FFFFFF;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #263238;
   color: #FFFFFF;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #FFFFFF;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #2C393F !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #C9CCD3;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #37474F !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #FFFFFF;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #2C393F !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #37474F !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #FFFFFF !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #37474F !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #EC5F67;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #37474F !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #263238 !important;
   color: #FFFFFF !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #FFFFFF !important;
   background: #37474F !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #37474F;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #37474F;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #263238;
   color: #FFFFFF;
   border-color: #37474F;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #37474F;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #263238;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #FFFFFF;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #263238;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #37474F;
   color: #FFFFFF;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #2C393F !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #2C393F !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #2C393F rgba(38, 50, 56, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(38, 50, 56, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #2C393F;
   border-radius: 0px;
   border: 2px solid #263238;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #36474e;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #263238;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #263238;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #263238;
   color: #FFFFFF;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #304047;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3b4d56;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-materia.rstheme
+++ b/inst/themes/base16/base16-materia.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Materia {rsthemes} */
 /* Materia by Defman21 */
@@ -18,26 +18,26 @@
   color: #FFFFFF;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #263238;
   color: #FFFFFF;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #263238;
   color: #FFFFFF;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #263238;
   color: #FFFFFF;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #FFFFFF;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #2C393F !important;
   color: #FFFFFF !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #2C393F !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #2C393F;
   border-color: #263238;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #263238;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #2C393F !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #C9CCD3;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #37474F !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #FFFFFF;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #2C393F !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #37474F !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #FFFFFF !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #37474F !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #EC5F67;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #37474F !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #263238 !important;
   color: #FFFFFF !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #FFFFFF !important;
   background: #37474F !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #37474F;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #37474F;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #263238;
   color: #FFFFFF;
   border-color: #37474F;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #37474F;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #263238;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #FFFFFF;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #263238;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #37474F;
   color: #FFFFFF;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #2C393F !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #2C393F !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #2C393F rgba(38, 50, 56, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(38, 50, 56, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #2C393F;
   border-radius: 0px;
   border: 2px solid #263238;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #36474e;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #263238;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #263238;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #263238;
   color: #FFFFFF;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #304047;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3b4d56;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-mexico-light.rstheme
+++ b/inst/themes/base16/base16-mexico-light.rstheme
@@ -18,35 +18,35 @@
   color: #181818;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #f8f8f8;
   color: #181818;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #f8f8f8;
   color: #181818;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #f8f8f8 !important;
   color: #181818 !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table {
+body .ace_editor_theme table {
   background-color: #f8f8f8 !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
+body .ace_editor_theme table thead > tr > th {
   background-color: #f8f8f8 !important;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme a {
+body.ace_editor_theme a {
   color: #181818 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-light-menus .gwt-Label {
+body .gwt-Label {
   color: #181818;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   background: #f8f8f8 !important;
   color: #181818 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
+body .rstudio-themes-default .rstudio-themes-background {
   background: #f8f8f8 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+body .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+body .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #f8f8f8;
   border-color: #f8f8f8;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
+body .rstudio-themes-default .rstudio-themes-border {
   border-color: #f8f8f8;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #d8d8d8 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #b8b8b8;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-default .rstheme_center,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #e8e8e8 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #383838;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #d8d8d8 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #e8e8e8 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #181818 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
+body .search, body.rstudio-themes-default-menus .search {
   /* search */
   background: #e8e8e8 !important;
 }
 
-.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #a16946;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
+.rstheme_secondaryToolbar, body .dataGridHeader {
   background: #e8e8e8 !important;
 }
 
 /* menu background */
-.rstudio-themes-light-menus .popupMiddleCenter,
-.rstudio-themes-light-menus .menuPopupMiddleCenter,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #f8f8f8 !important;
   color: #181818 !important;
 }
 
-.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #181818 !important;
   background: #d8d8d8 !important;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #d8d8d8;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #d8d8d8;
 }
 
-.rstudio-themes-light-menus .popupContent {
+body .popupContent {
   background: #f8f8f8;
   color: #181818;
   border-color: #d8d8d8;
 }
 
-.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #d8d8d8;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #f8f8f8;
   padding: 2px;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #181818;
   border: 0;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #f8f8f8;
 }
 
-.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #d8d8d8;
   color: #181818;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #d8d8d8 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #d8d8d8 !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-light-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
+body, body .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #e8e8e8 rgba(248, 248, 248, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(248, 248, 248, 0.5);
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #e8e8e8;
   border-radius: 0px;
   border: 2px solid #f8f8f8;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #dbdbdb;
 }
 
@@ -529,49 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #f8f8f8;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #f8f8f8;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #f8f8f8;
   color: #181818;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #ebebeb;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #dfdfdf;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-mexico-light.rstheme
+++ b/inst/themes/base16/base16-mexico-light.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Mexico Light {rsthemes} */
 /* Mexico Light by Sheldon Johnson */
@@ -18,35 +18,35 @@
   color: #181818;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-light-menus.ace_editor_theme {
   background-color: #f8f8f8;
   color: #181818;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #f8f8f8;
   color: #181818;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-light-menus .ace_editor_theme {
   background-color: #f8f8f8 !important;
   color: #181818 !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table {
+.rstudio-themes-light-menus .ace_editor_theme table {
   background-color: #f8f8f8 !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table thead > tr > th {
+.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
   background-color: #f8f8f8 !important;
 }
 
-.rstudio-themes-flat.ace_editor_theme a {
+.rstudio-themes-light-menus.ace_editor_theme a {
   color: #181818 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-light-menus .gwt-Label {
   color: #181818;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   background: #f8f8f8 !important;
   color: #181818 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
   background: #f8f8f8 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #f8f8f8;
   border-color: #f8f8f8;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
   border-color: #f8f8f8;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #d8d8d8 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #b8b8b8;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-default .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #e8e8e8 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #383838;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #d8d8d8 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper {
   background: #e8e8e8 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
   color: #181818 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .search, .rstudio-themes-flat.rstudio-themes-default-menus .search {
+.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
   /* search */
   background: #e8e8e8 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #a16946;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
   background: #e8e8e8 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-light-menus .popupMiddleCenter,
+.rstudio-themes-light-menus .menuPopupMiddleCenter,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter {
   background: #f8f8f8 !important;
   color: #181818 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #181818 !important;
   background: #d8d8d8 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-light-menus .themedPopupPanel {
   border: solid 1px #d8d8d8;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #d8d8d8;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-light-menus .popupContent {
   background: #f8f8f8;
   color: #181818;
   border-color: #d8d8d8;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #d8d8d8;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
   background: #f8f8f8;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
   background: #181818;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #f8f8f8;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #d8d8d8;
   color: #181818;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #d8d8d8 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #d8d8d8 !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-light-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #e8e8e8 rgba(248, 248, 248, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(248, 248, 248, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #e8e8e8;
   border-radius: 0px;
   border: 2px solid #f8f8f8;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #dbdbdb;
 }
 
@@ -529,35 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #f8f8f8;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #f8f8f8;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #f8f8f8;
   color: #181818;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #ebebeb;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #dfdfdf;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-mocha.rstheme
+++ b/inst/themes/base16/base16-mocha.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Mocha {rsthemes} */
 /* Mocha by Chris Kempson (http://chriskempson.com) */
@@ -18,26 +18,26 @@
   color: #f5eeeb;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #3B3228;
   color: #f5eeeb;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #3B3228;
   color: #f5eeeb;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #3B3228;
   color: #f5eeeb;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #f5eeeb;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #534636 !important;
   color: #f5eeeb !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #534636 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #534636;
   border-color: #3B3228;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #3B3228;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #534636 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #b8afad;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #645240 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f5eeeb;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #534636 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #645240 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #f5eeeb !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #645240 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #bb9584;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #645240 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #3B3228 !important;
   color: #f5eeeb !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #f5eeeb !important;
   background: #645240 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #645240;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #645240;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #3B3228;
   color: #f5eeeb;
   border-color: #645240;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #645240;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #3B3228;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #f5eeeb;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #3B3228;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #645240;
   color: #f5eeeb;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #534636 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #534636 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #534636 rgba(59, 50, 40, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(59, 50, 40, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #534636;
   border-radius: 0px;
   border: 2px solid #3B3228;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #625340;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #3B3228;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #3B3228;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #3B3228;
   color: #f5eeeb;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #4a3f32;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #594c3d;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-mocha.rstheme
+++ b/inst/themes/base16/base16-mocha.rstheme
@@ -18,26 +18,26 @@
   color: #f5eeeb;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #3B3228;
   color: #f5eeeb;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #3B3228;
   color: #f5eeeb;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #3B3228;
   color: #f5eeeb;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #f5eeeb;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #534636 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #b8afad;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #645240 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f5eeeb;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #534636 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #645240 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #f5eeeb !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #645240 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #bb9584;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #645240 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #3B3228 !important;
   color: #f5eeeb !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #f5eeeb !important;
   background: #645240 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #645240;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #645240;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #3B3228;
   color: #f5eeeb;
   border-color: #645240;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #645240;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #3B3228;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #f5eeeb;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #3B3228;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #645240;
   color: #f5eeeb;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #534636 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #534636 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #534636 rgba(59, 50, 40, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(59, 50, 40, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #534636;
   border-radius: 0px;
   border: 2px solid #3B3228;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #625340;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #3B3228;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #3B3228;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #3B3228;
   color: #f5eeeb;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #4a3f32;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #594c3d;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-monokai.rstheme
+++ b/inst/themes/base16/base16-monokai.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Monokai {rsthemes} */
 /* Monokai by Wimer Hazenberg (http://www.monokai.nl) */
@@ -18,26 +18,26 @@
   color: #f9f8f5;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #272822;
   color: #f9f8f5;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #272822;
   color: #f9f8f5;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #272822;
   color: #f9f8f5;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #f9f8f5;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #383830 !important;
   color: #f9f8f5 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #383830 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #383830;
   border-color: #272822;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #272822;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #383830 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #a59f85;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #49483e !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f9f8f5;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #383830 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #49483e !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #f9f8f5 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #49483e !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #cc6633;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #49483e !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #272822 !important;
   color: #f9f8f5 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #f9f8f5 !important;
   background: #49483e !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #49483e;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #49483e;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #272822;
   color: #f9f8f5;
   border-color: #49483e;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #49483e;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #272822;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #f9f8f5;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #272822;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #49483e;
   color: #f9f8f5;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #383830 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #383830 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #383830 rgba(39, 40, 34, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(39, 40, 34, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #383830;
   border-radius: 0px;
   border: 2px solid #272822;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #46463c;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #272822;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #272822;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #272822;
   color: #f9f8f5;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #34362e;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #424439;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-monokai.rstheme
+++ b/inst/themes/base16/base16-monokai.rstheme
@@ -18,26 +18,26 @@
   color: #f9f8f5;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #272822;
   color: #f9f8f5;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #272822;
   color: #f9f8f5;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #272822;
   color: #f9f8f5;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #f9f8f5;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #383830 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #a59f85;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #49483e !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f9f8f5;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #383830 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #49483e !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #f9f8f5 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #49483e !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #cc6633;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #49483e !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #272822 !important;
   color: #f9f8f5 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #f9f8f5 !important;
   background: #49483e !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #49483e;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #49483e;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #272822;
   color: #f9f8f5;
   border-color: #49483e;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #49483e;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #272822;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #f9f8f5;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #272822;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #49483e;
   color: #f9f8f5;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #383830 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #383830 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #383830 rgba(39, 40, 34, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(39, 40, 34, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #383830;
   border-radius: 0px;
   border: 2px solid #272822;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #46463c;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #272822;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #272822;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #272822;
   color: #f9f8f5;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #34362e;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #424439;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-nord.rstheme
+++ b/inst/themes/base16/base16-nord.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Nord {rsthemes} */
 /* Nord by arcticicestudio */
@@ -18,26 +18,26 @@
   color: #8FBCBB;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #2E3440;
   color: #8FBCBB;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #2E3440;
   color: #8FBCBB;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #2E3440;
   color: #8FBCBB;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #8FBCBB;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #3B4252 !important;
   color: #8FBCBB !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #3B4252 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #3B4252;
   border-color: #2E3440;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #2E3440;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #3B4252 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #D8DEE9;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #434C5E !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #8FBCBB;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #3B4252 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #434C5E !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #8FBCBB !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #434C5E !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #B48EAD;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #434C5E !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #2E3440 !important;
   color: #8FBCBB !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #8FBCBB !important;
   background: #434C5E !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #434C5E;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #434C5E;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #2E3440;
   color: #8FBCBB;
   border-color: #434C5E;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #434C5E;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #2E3440;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #8FBCBB;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #2E3440;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #434C5E;
   color: #8FBCBB;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #3B4252 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #3B4252 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #3B4252 rgba(46, 52, 64, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(46, 52, 64, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #3B4252;
   border-radius: 0px;
   border: 2px solid #2E3440;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #464e61;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #2E3440;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #2E3440;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #2E3440;
   color: #8FBCBB;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #39404f;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #434c5e;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-nord.rstheme
+++ b/inst/themes/base16/base16-nord.rstheme
@@ -18,26 +18,26 @@
   color: #8FBCBB;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #2E3440;
   color: #8FBCBB;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #2E3440;
   color: #8FBCBB;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #2E3440;
   color: #8FBCBB;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #8FBCBB;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #3B4252 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #D8DEE9;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #434C5E !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #8FBCBB;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #3B4252 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #434C5E !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #8FBCBB !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #434C5E !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #B48EAD;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #434C5E !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #2E3440 !important;
   color: #8FBCBB !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #8FBCBB !important;
   background: #434C5E !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #434C5E;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #434C5E;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #2E3440;
   color: #8FBCBB;
   border-color: #434C5E;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #434C5E;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #2E3440;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #8FBCBB;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #2E3440;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #434C5E;
   color: #8FBCBB;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #3B4252 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #3B4252 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #3B4252 rgba(46, 52, 64, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(46, 52, 64, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #3B4252;
   border-radius: 0px;
   border: 2px solid #2E3440;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #464e61;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #2E3440;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #2E3440;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #2E3440;
   color: #8FBCBB;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #39404f;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #434c5e;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-ocean.rstheme
+++ b/inst/themes/base16/base16-ocean.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Ocean {rsthemes} */
 /* Ocean by Chris Kempson (http://chriskempson.com) */
@@ -18,26 +18,26 @@
   color: #eff1f5;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #2b303b;
   color: #eff1f5;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #2b303b;
   color: #eff1f5;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #2b303b;
   color: #eff1f5;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #eff1f5;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #343d46 !important;
   color: #eff1f5 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #343d46 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #343d46;
   border-color: #2b303b;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #2b303b;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #343d46 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #a7adba;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #4f5b66 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #eff1f5;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #343d46 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #4f5b66 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #eff1f5 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #4f5b66 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #ab7967;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #4f5b66 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #2b303b !important;
   color: #eff1f5 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #eff1f5 !important;
   background: #4f5b66 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #4f5b66;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #4f5b66;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #2b303b;
   color: #eff1f5;
   border-color: #4f5b66;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #4f5b66;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #2b303b;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #eff1f5;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #2b303b;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #4f5b66;
   color: #eff1f5;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #343d46 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #343d46 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #343d46 rgba(43, 48, 59, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(43, 48, 59, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #343d46;
   border-radius: 0px;
   border: 2px solid #2b303b;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #3f4a55;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #2b303b;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #2b303b;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #2b303b;
   color: #eff1f5;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #363c4a;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #414859;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-ocean.rstheme
+++ b/inst/themes/base16/base16-ocean.rstheme
@@ -18,26 +18,26 @@
   color: #eff1f5;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #2b303b;
   color: #eff1f5;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #2b303b;
   color: #eff1f5;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #2b303b;
   color: #eff1f5;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #eff1f5;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #343d46 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #a7adba;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #4f5b66 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #eff1f5;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #343d46 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #4f5b66 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #eff1f5 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #4f5b66 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #ab7967;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #4f5b66 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #2b303b !important;
   color: #eff1f5 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #eff1f5 !important;
   background: #4f5b66 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #4f5b66;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #4f5b66;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #2b303b;
   color: #eff1f5;
   border-color: #4f5b66;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #4f5b66;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #2b303b;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #eff1f5;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #2b303b;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #4f5b66;
   color: #eff1f5;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #343d46 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #343d46 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #343d46 rgba(43, 48, 59, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(43, 48, 59, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #343d46;
   border-radius: 0px;
   border: 2px solid #2b303b;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #3f4a55;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #2b303b;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #2b303b;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #2b303b;
   color: #eff1f5;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #363c4a;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #414859;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-oceanicnext.rstheme
+++ b/inst/themes/base16/base16-oceanicnext.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 OceanicNext {rsthemes} */
 /* OceanicNext by https://github.com/voronianski/oceanic-next-color-scheme */
@@ -18,26 +18,26 @@
   color: #D8DEE9;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #1B2B34;
   color: #D8DEE9;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #1B2B34;
   color: #D8DEE9;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #1B2B34;
   color: #D8DEE9;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #D8DEE9;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #343D46 !important;
   color: #D8DEE9 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #343D46 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #343D46;
   border-color: #1B2B34;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #1B2B34;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #343D46 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #A7ADBA;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #4F5B66 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #D8DEE9;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #343D46 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #4F5B66 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #D8DEE9 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #4F5B66 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #AB7967;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #4F5B66 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #1B2B34 !important;
   color: #D8DEE9 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #D8DEE9 !important;
   background: #4F5B66 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #4F5B66;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #4F5B66;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #1B2B34;
   color: #D8DEE9;
   border-color: #4F5B66;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #4F5B66;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #1B2B34;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #D8DEE9;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1B2B34;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #4F5B66;
   color: #D8DEE9;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #343D46 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #343D46 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #343D46 rgba(27, 43, 52, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(27, 43, 52, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #343D46;
   border-radius: 0px;
   border: 2px solid #1B2B34;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #3f4a55;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #1B2B34;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #1B2B34;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1B2B34;
   color: #D8DEE9;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #243945;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #2c4756;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-oceanicnext.rstheme
+++ b/inst/themes/base16/base16-oceanicnext.rstheme
@@ -18,26 +18,26 @@
   color: #D8DEE9;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #1B2B34;
   color: #D8DEE9;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #1B2B34;
   color: #D8DEE9;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #1B2B34;
   color: #D8DEE9;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #D8DEE9;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #343D46 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #A7ADBA;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #4F5B66 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #D8DEE9;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #343D46 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #4F5B66 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #D8DEE9 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #4F5B66 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #AB7967;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #4F5B66 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #1B2B34 !important;
   color: #D8DEE9 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #D8DEE9 !important;
   background: #4F5B66 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #4F5B66;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #4F5B66;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #1B2B34;
   color: #D8DEE9;
   border-color: #4F5B66;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #4F5B66;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #1B2B34;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #D8DEE9;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1B2B34;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #4F5B66;
   color: #D8DEE9;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #343D46 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #343D46 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #343D46 rgba(27, 43, 52, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(27, 43, 52, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #343D46;
   border-radius: 0px;
   border: 2px solid #1B2B34;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #3f4a55;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #1B2B34;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #1B2B34;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1B2B34;
   color: #D8DEE9;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #243945;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #2c4756;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-onedark.rstheme
+++ b/inst/themes/base16/base16-onedark.rstheme
@@ -18,26 +18,26 @@
   color: #c8ccd4;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #282c34;
   color: #c8ccd4;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #282c34;
   color: #c8ccd4;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #282c34;
   color: #c8ccd4;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #c8ccd4;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #353b45 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #565c64;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #3e4451 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #c8ccd4;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #353b45 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #3e4451 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #c8ccd4 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #3e4451 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #be5046;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #3e4451 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #282c34 !important;
   color: #c8ccd4 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #c8ccd4 !important;
   background: #3e4451 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #3e4451;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #3e4451;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #282c34;
   color: #c8ccd4;
   border-color: #3e4451;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #3e4451;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #282c34;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #c8ccd4;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #282c34;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #3e4451;
   color: #c8ccd4;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #353b45 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #353b45 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #353b45 rgba(40, 44, 52, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(40, 44, 52, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #353b45;
   border-radius: 0px;
   border: 2px solid #282c34;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #404753;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #282c34;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #282c34;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #282c34;
   color: #c8ccd4;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #333842;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3e4451;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-onedark.rstheme
+++ b/inst/themes/base16/base16-onedark.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 OneDark {rsthemes} */
 /* OneDark by Lalit Magant (http://github.com/tilal6991) */
@@ -18,26 +18,26 @@
   color: #c8ccd4;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #282c34;
   color: #c8ccd4;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #282c34;
   color: #c8ccd4;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #282c34;
   color: #c8ccd4;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #c8ccd4;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #353b45 !important;
   color: #c8ccd4 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #353b45 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #353b45;
   border-color: #282c34;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #282c34;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #353b45 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #565c64;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #3e4451 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #c8ccd4;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #353b45 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #3e4451 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #c8ccd4 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #3e4451 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #be5046;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #3e4451 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #282c34 !important;
   color: #c8ccd4 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #c8ccd4 !important;
   background: #3e4451 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #3e4451;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #3e4451;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #282c34;
   color: #c8ccd4;
   border-color: #3e4451;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #3e4451;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #282c34;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #c8ccd4;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #282c34;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #3e4451;
   color: #c8ccd4;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #353b45 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #353b45 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #353b45 rgba(40, 44, 52, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(40, 44, 52, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #353b45;
   border-radius: 0px;
   border: 2px solid #282c34;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #404753;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #282c34;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #282c34;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #282c34;
   color: #c8ccd4;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #333842;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3e4451;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-paraiso.rstheme
+++ b/inst/themes/base16/base16-paraiso.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Paraiso {rsthemes} */
 /* Paraiso by Jan T. Sott */
@@ -18,26 +18,26 @@
   color: #e7e9db;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #2f1e2e;
   color: #e7e9db;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #2f1e2e;
   color: #e7e9db;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #2f1e2e;
   color: #e7e9db;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #e7e9db;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #41323f !important;
   color: #e7e9db !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #41323f !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #41323f;
   border-color: #2f1e2e;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #2f1e2e;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #41323f !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #8d8687;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #4f424c !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #e7e9db;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #41323f !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #4f424c !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #e7e9db !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #4f424c !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #e96ba8;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #4f424c !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #2f1e2e !important;
   color: #e7e9db !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #e7e9db !important;
   background: #4f424c !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #4f424c;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #4f424c;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #2f1e2e;
   color: #e7e9db;
   border-color: #4f424c;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #4f424c;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #2f1e2e;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #e7e9db;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #2f1e2e;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #4f424c;
   color: #e7e9db;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #41323f !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #41323f !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #41323f rgba(47, 30, 46, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(47, 30, 46, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #41323f;
   border-radius: 0px;
   border: 2px solid #2f1e2e;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #4f3d4d;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #2f1e2e;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #2f1e2e;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #2f1e2e;
   color: #e7e9db;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #3f283d;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #4e324c;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-paraiso.rstheme
+++ b/inst/themes/base16/base16-paraiso.rstheme
@@ -18,26 +18,26 @@
   color: #e7e9db;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #2f1e2e;
   color: #e7e9db;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #2f1e2e;
   color: #e7e9db;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #2f1e2e;
   color: #e7e9db;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #e7e9db;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #41323f !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #8d8687;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #4f424c !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #e7e9db;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #41323f !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #4f424c !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #e7e9db !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #4f424c !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #e96ba8;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #4f424c !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #2f1e2e !important;
   color: #e7e9db !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #e7e9db !important;
   background: #4f424c !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #4f424c;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #4f424c;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #2f1e2e;
   color: #e7e9db;
   border-color: #4f424c;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #4f424c;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #2f1e2e;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #e7e9db;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #2f1e2e;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #4f424c;
   color: #e7e9db;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #41323f !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #41323f !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #41323f rgba(47, 30, 46, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(47, 30, 46, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #41323f;
   border-radius: 0px;
   border: 2px solid #2f1e2e;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #4f3d4d;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #2f1e2e;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #2f1e2e;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #2f1e2e;
   color: #e7e9db;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #3f283d;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #4e324c;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-phd.rstheme
+++ b/inst/themes/base16/base16-phd.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 PhD {rsthemes} */
 /* PhD by Hennig Hasemann (http://leetless.de/vim.html) */
@@ -18,26 +18,26 @@
   color: #ffffff;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #061229;
   color: #ffffff;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #061229;
   color: #ffffff;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #061229;
   color: #ffffff;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #ffffff;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #2a3448 !important;
   color: #ffffff !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #2a3448 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #2a3448;
   border-color: #061229;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #061229;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #2a3448 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #9a99a3;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #4d5666 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #2a3448 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #4d5666 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #4d5666 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #b08060;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #4d5666 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #061229 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #ffffff !important;
   background: #4d5666 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #4d5666;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #4d5666;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #061229;
   color: #ffffff;
   border-color: #4d5666;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #4d5666;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #061229;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #ffffff;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #061229;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #4d5666;
   color: #ffffff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #2a3448 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #2a3448 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #2a3448 rgba(6, 18, 41, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(6, 18, 41, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #2a3448;
   border-radius: 0px;
   border: 2px solid #061229;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #334058;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #061229;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #061229;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #061229;
   color: #ffffff;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #091c3f;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #0d2655;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-phd.rstheme
+++ b/inst/themes/base16/base16-phd.rstheme
@@ -18,26 +18,26 @@
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #061229;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #061229;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #061229;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #ffffff;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #2a3448 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #9a99a3;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #4d5666 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #2a3448 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #4d5666 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #ffffff !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #4d5666 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #b08060;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #4d5666 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #061229 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #ffffff !important;
   background: #4d5666 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #4d5666;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #4d5666;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #061229;
   color: #ffffff;
   border-color: #4d5666;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #4d5666;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #061229;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #ffffff;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #061229;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #4d5666;
   color: #ffffff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #2a3448 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #2a3448 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #2a3448 rgba(6, 18, 41, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(6, 18, 41, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #2a3448;
   border-radius: 0px;
   border: 2px solid #061229;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #334058;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #061229;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #061229;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #061229;
   color: #ffffff;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #091c3f;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #0d2655;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-pico.rstheme
+++ b/inst/themes/base16/base16-pico.rstheme
@@ -18,26 +18,26 @@
   color: #fff1e8;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #000000;
   color: #fff1e8;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #000000;
   color: #fff1e8;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #000000;
   color: #fff1e8;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #fff1e8;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #1d2b53 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #ab5236;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #7e2553 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #fff1e8;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #1d2b53 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #7e2553 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #fff1e8 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #7e2553 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #ffccaa;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #7e2553 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #000000 !important;
   color: #fff1e8 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #fff1e8 !important;
   background: #7e2553 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #7e2553;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #7e2553;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #000000;
   color: #fff1e8;
   border-color: #7e2553;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #7e2553;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #000000;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #fff1e8;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #000000;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #7e2553;
   color: #fff1e8;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #1d2b53 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #1d2b53 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #1d2b53 rgba(0, 0, 0, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(0, 0, 0, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #1d2b53;
   border-radius: 0px;
   border: 2px solid #000000;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #243566;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #000000;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #000000;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #000000;
   color: #fff1e8;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #0d0d0d;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #1a1a1a;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-pico.rstheme
+++ b/inst/themes/base16/base16-pico.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Pico {rsthemes} */
 /* Pico by PICO-8 (http://www.lexaloffle.com/pico-8.php) */
@@ -18,26 +18,26 @@
   color: #fff1e8;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #000000;
   color: #fff1e8;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #000000;
   color: #fff1e8;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #000000;
   color: #fff1e8;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #fff1e8;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #1d2b53 !important;
   color: #fff1e8 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #1d2b53 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #1d2b53;
   border-color: #000000;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #000000;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #1d2b53 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #ab5236;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #7e2553 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #fff1e8;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #1d2b53 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #7e2553 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #fff1e8 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #7e2553 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #ffccaa;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #7e2553 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #000000 !important;
   color: #fff1e8 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #fff1e8 !important;
   background: #7e2553 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #7e2553;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #7e2553;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #000000;
   color: #fff1e8;
   border-color: #7e2553;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #7e2553;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #000000;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #fff1e8;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #000000;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #7e2553;
   color: #fff1e8;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #1d2b53 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #1d2b53 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #1d2b53 rgba(0, 0, 0, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(0, 0, 0, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #1d2b53;
   border-radius: 0px;
   border: 2px solid #000000;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #243566;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #000000;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #000000;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #000000;
   color: #fff1e8;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #0d0d0d;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #1a1a1a;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-pop.rstheme
+++ b/inst/themes/base16/base16-pop.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Pop {rsthemes} */
 /* Pop by Chris Kempson (http://chriskempson.com) */
@@ -18,26 +18,26 @@
   color: #ffffff;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #ffffff;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #202020 !important;
   color: #ffffff !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #202020 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #202020;
   border-color: #000000;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #000000;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #202020 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #b0b0b0;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #303030 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #202020 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #303030 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #303030 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #7a2d00;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #303030 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #000000 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #ffffff !important;
   background: #303030 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #303030;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #303030;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #000000;
   color: #ffffff;
   border-color: #303030;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #303030;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #000000;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #ffffff;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #000000;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #303030;
   color: #ffffff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #202020 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #202020 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #202020 rgba(0, 0, 0, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(0, 0, 0, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #202020;
   border-radius: 0px;
   border: 2px solid #000000;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #2d2d2d;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #000000;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #000000;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #0d0d0d;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #1a1a1a;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-pop.rstheme
+++ b/inst/themes/base16/base16-pop.rstheme
@@ -18,26 +18,26 @@
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #ffffff;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #202020 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #b0b0b0;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #303030 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #202020 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #303030 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #ffffff !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #303030 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #7a2d00;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #303030 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #000000 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #ffffff !important;
   background: #303030 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #303030;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #303030;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #000000;
   color: #ffffff;
   border-color: #303030;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #303030;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #000000;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #ffffff;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #000000;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #303030;
   color: #ffffff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #202020 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #202020 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #202020 rgba(0, 0, 0, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(0, 0, 0, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #202020;
   border-radius: 0px;
   border: 2px solid #000000;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #2d2d2d;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #000000;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #000000;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #000000;
   color: #ffffff;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #0d0d0d;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #1a1a1a;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-railscasts.rstheme
+++ b/inst/themes/base16/base16-railscasts.rstheme
@@ -18,26 +18,26 @@
   color: #f9f7f3;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #2b2b2b;
   color: #f9f7f3;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #2b2b2b;
   color: #f9f7f3;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #2b2b2b;
   color: #f9f7f3;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #f9f7f3;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #272935 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #d4cfc9;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #3a4055 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f9f7f3;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #272935 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #3a4055 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #f9f7f3 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #3a4055 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #bc9458;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #3a4055 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #2b2b2b !important;
   color: #f9f7f3 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #f9f7f3 !important;
   background: #3a4055 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #3a4055;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #3a4055;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #2b2b2b;
   color: #f9f7f3;
   border-color: #3a4055;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #3a4055;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #2b2b2b;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #f9f7f3;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #2b2b2b;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #3a4055;
   color: #f9f7f3;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #272935 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #272935 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #272935 rgba(43, 43, 43, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(43, 43, 43, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #272935;
   border-radius: 0px;
   border: 2px solid #2b2b2b;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #323444;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #2b2b2b;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #2b2b2b;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #2b2b2b;
   color: #f9f7f3;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #383838;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #454545;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-railscasts.rstheme
+++ b/inst/themes/base16/base16-railscasts.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Railscasts {rsthemes} */
 /* Railscasts by Ryan Bates (http://railscasts.com) */
@@ -18,26 +18,26 @@
   color: #f9f7f3;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #2b2b2b;
   color: #f9f7f3;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #2b2b2b;
   color: #f9f7f3;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #2b2b2b;
   color: #f9f7f3;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #f9f7f3;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #272935 !important;
   color: #f9f7f3 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #272935 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #272935;
   border-color: #2b2b2b;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #2b2b2b;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #272935 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #d4cfc9;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #3a4055 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f9f7f3;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #272935 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #3a4055 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #f9f7f3 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #3a4055 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #bc9458;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #3a4055 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #2b2b2b !important;
   color: #f9f7f3 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #f9f7f3 !important;
   background: #3a4055 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #3a4055;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #3a4055;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #2b2b2b;
   color: #f9f7f3;
   border-color: #3a4055;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #3a4055;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #2b2b2b;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #f9f7f3;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #2b2b2b;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #3a4055;
   color: #f9f7f3;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #272935 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #272935 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #272935 rgba(43, 43, 43, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(43, 43, 43, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #272935;
   border-radius: 0px;
   border: 2px solid #2b2b2b;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #323444;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #2b2b2b;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #2b2b2b;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #2b2b2b;
   color: #f9f7f3;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #383838;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #454545;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-rebecca.rstheme
+++ b/inst/themes/base16/base16-rebecca.rstheme
@@ -18,26 +18,26 @@
   color: #53495d;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #292a44;
   color: #53495d;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #292a44;
   color: #53495d;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #292a44;
   color: #53495d;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #53495d;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #663399 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #a0a0c5;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #383a62 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #53495d;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #663399 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #383a62 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #53495d !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #383a62 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #ff79c6;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #383a62 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #292a44 !important;
   color: #53495d !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #53495d !important;
   background: #383a62 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #383a62;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #383a62;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #292a44;
   color: #53495d;
   border-color: #383a62;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #383a62;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #292a44;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #53495d;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #292a44;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #383a62;
   color: #53495d;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #663399 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #663399 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #663399 rgba(41, 42, 68, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(41, 42, 68, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #663399;
   border-radius: 0px;
   border: 2px solid #292a44;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #7339ac;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #292a44;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #292a44;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #292a44;
   color: #53495d;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #333454;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3c3e64;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-rebecca.rstheme
+++ b/inst/themes/base16/base16-rebecca.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Rebecca {rsthemes} */
 /* Rebecca by Victor Borja (http://github.com/vic) based on Rebecca Theme (http://github.com/vic/rebecca-theme) */
@@ -18,26 +18,26 @@
   color: #53495d;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #292a44;
   color: #53495d;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #292a44;
   color: #53495d;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #292a44;
   color: #53495d;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #53495d;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #663399 !important;
   color: #53495d !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #663399 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #663399;
   border-color: #292a44;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #292a44;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #663399 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #a0a0c5;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #383a62 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #53495d;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #663399 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #383a62 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #53495d !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #383a62 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #ff79c6;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #383a62 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #292a44 !important;
   color: #53495d !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #53495d !important;
   background: #383a62 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #383a62;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #383a62;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #292a44;
   color: #53495d;
   border-color: #383a62;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #383a62;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #292a44;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #53495d;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #292a44;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #383a62;
   color: #53495d;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #663399 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #663399 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #663399 rgba(41, 42, 68, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(41, 42, 68, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #663399;
   border-radius: 0px;
   border: 2px solid #292a44;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #7339ac;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #292a44;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #292a44;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #292a44;
   color: #53495d;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #333454;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3c3e64;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-seti-ui.rstheme
+++ b/inst/themes/base16/base16-seti-ui.rstheme
@@ -18,26 +18,26 @@
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #151718;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #151718;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #151718;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #ffffff;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #8ec43d !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #43a5d5;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #3B758C !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #8ec43d !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #3B758C !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #ffffff !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #3B758C !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #8a553f;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #3B758C !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #151718 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #ffffff !important;
   background: #3B758C !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #3B758C;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #3B758C;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #151718;
   color: #ffffff;
   border-color: #3B758C;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #3B758C;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #151718;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #ffffff;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #151718;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #3B758C;
   color: #ffffff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #8ec43d !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #8ec43d !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #8ec43d rgba(21, 23, 24, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(21, 23, 24, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #8ec43d;
   border-radius: 0px;
   border: 2px solid #151718;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #99ca51;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #151718;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #151718;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #151718;
   color: #ffffff;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #212426;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #2d3133;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-seti-ui.rstheme
+++ b/inst/themes/base16/base16-seti-ui.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Seti UI {rsthemes} */
 /* Seti UI by  */
@@ -18,26 +18,26 @@
   color: #ffffff;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #151718;
   color: #ffffff;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #151718;
   color: #ffffff;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #151718;
   color: #ffffff;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #ffffff;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #8ec43d !important;
   color: #ffffff !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #8ec43d !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #8ec43d;
   border-color: #151718;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #151718;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #8ec43d !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #43a5d5;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #3B758C !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #8ec43d !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #3B758C !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #3B758C !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #8a553f;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #3B758C !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #151718 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #ffffff !important;
   background: #3B758C !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #3B758C;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #3B758C;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #151718;
   color: #ffffff;
   border-color: #3B758C;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #3B758C;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #151718;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #ffffff;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #151718;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #3B758C;
   color: #ffffff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #8ec43d !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #8ec43d !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #8ec43d rgba(21, 23, 24, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(21, 23, 24, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #8ec43d;
   border-radius: 0px;
   border: 2px solid #151718;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #99ca51;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #151718;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #151718;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #151718;
   color: #ffffff;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #212426;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #2d3133;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-shapeshifter.rstheme
+++ b/inst/themes/base16/base16-shapeshifter.rstheme
@@ -18,35 +18,35 @@
   color: #000000;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #f9f9f9;
   color: #000000;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #f9f9f9;
   color: #000000;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #f9f9f9 !important;
   color: #000000 !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table {
+body .ace_editor_theme table {
   background-color: #f9f9f9 !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
+body .ace_editor_theme table thead > tr > th {
   background-color: #f9f9f9 !important;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme a {
+body.ace_editor_theme a {
   color: #000000 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-light-menus .gwt-Label {
+body .gwt-Label {
   color: #000000;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   background: #f9f9f9 !important;
   color: #000000 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
+body .rstudio-themes-default .rstudio-themes-background {
   background: #f9f9f9 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+body .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+body .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #f9f9f9;
   border-color: #f9f9f9;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
+body .rstudio-themes-default .rstudio-themes-border {
   border-color: #f9f9f9;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #ababab !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #555555;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-default .rstheme_center,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #e0e0e0 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #102015;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #ababab !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #e0e0e0 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #000000 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
+body .search, body.rstudio-themes-default-menus .search {
   /* search */
   background: #e0e0e0 !important;
 }
 
-.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #69542d;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
+.rstheme_secondaryToolbar, body .dataGridHeader {
   background: #e0e0e0 !important;
 }
 
 /* menu background */
-.rstudio-themes-light-menus .popupMiddleCenter,
-.rstudio-themes-light-menus .menuPopupMiddleCenter,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #f9f9f9 !important;
   color: #000000 !important;
 }
 
-.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #000000 !important;
   background: #ababab !important;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #ababab;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #ababab;
 }
 
-.rstudio-themes-light-menus .popupContent {
+body .popupContent {
   background: #f9f9f9;
   color: #000000;
   border-color: #ababab;
 }
 
-.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #ababab;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #f9f9f9;
   padding: 2px;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #000000;
   border: 0;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #f9f9f9;
 }
 
-.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #ababab;
   color: #000000;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #ababab !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #ababab !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-light-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
+body, body .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #e0e0e0 rgba(249, 249, 249, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(249, 249, 249, 0.5);
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #e0e0e0;
   border-radius: 0px;
   border: 2px solid #f9f9f9;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: lightgray;
 }
 
@@ -529,49 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #f9f9f9;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #f9f9f9;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #f9f9f9;
   color: #000000;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #ececec;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #e0e0e0;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-shapeshifter.rstheme
+++ b/inst/themes/base16/base16-shapeshifter.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Shapeshifter {rsthemes} */
 /* Shapeshifter by Tyler Benziger (http://tybenz.com) */
@@ -18,35 +18,35 @@
   color: #000000;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-light-menus.ace_editor_theme {
   background-color: #f9f9f9;
   color: #000000;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #f9f9f9;
   color: #000000;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-light-menus .ace_editor_theme {
   background-color: #f9f9f9 !important;
   color: #000000 !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table {
+.rstudio-themes-light-menus .ace_editor_theme table {
   background-color: #f9f9f9 !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table thead > tr > th {
+.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
   background-color: #f9f9f9 !important;
 }
 
-.rstudio-themes-flat.ace_editor_theme a {
+.rstudio-themes-light-menus.ace_editor_theme a {
   color: #000000 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-light-menus .gwt-Label {
   color: #000000;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   background: #f9f9f9 !important;
   color: #000000 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
   background: #f9f9f9 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #f9f9f9;
   border-color: #f9f9f9;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
   border-color: #f9f9f9;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #ababab !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #555555;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-default .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #e0e0e0 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #102015;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #ababab !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper {
   background: #e0e0e0 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
   color: #000000 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .search, .rstudio-themes-flat.rstudio-themes-default-menus .search {
+.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
   /* search */
   background: #e0e0e0 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #69542d;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
   background: #e0e0e0 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-light-menus .popupMiddleCenter,
+.rstudio-themes-light-menus .menuPopupMiddleCenter,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter {
   background: #f9f9f9 !important;
   color: #000000 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #000000 !important;
   background: #ababab !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-light-menus .themedPopupPanel {
   border: solid 1px #ababab;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #ababab;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-light-menus .popupContent {
   background: #f9f9f9;
   color: #000000;
   border-color: #ababab;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #ababab;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
   background: #f9f9f9;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
   background: #000000;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #f9f9f9;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #ababab;
   color: #000000;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #ababab !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #ababab !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-light-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #e0e0e0 rgba(249, 249, 249, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(249, 249, 249, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #e0e0e0;
   border-radius: 0px;
   border: 2px solid #f9f9f9;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: lightgray;
 }
 
@@ -529,35 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #f9f9f9;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #f9f9f9;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #f9f9f9;
   color: #000000;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #ececec;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #e0e0e0;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-solar-flare.rstheme
+++ b/inst/themes/base16/base16-solar-flare.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Solar Flare {rsthemes} */
 /* Solar Flare by Chuck Harmston (https://chuck.harmston.ch) */
@@ -18,26 +18,26 @@
   color: #F5F7FA;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #18262F;
   color: #F5F7FA;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #18262F;
   color: #F5F7FA;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #18262F;
   color: #F5F7FA;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #F5F7FA;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #222E38 !important;
   color: #F5F7FA !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #222E38 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #222E38;
   border-color: #18262F;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #18262F;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #222E38 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #85939E;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #586875 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #F5F7FA;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #222E38 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #586875 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #F5F7FA !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #586875 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #D73C9A;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #586875 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #18262F !important;
   color: #F5F7FA !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #F5F7FA !important;
   background: #586875 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #586875;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #586875;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #18262F;
   color: #F5F7FA;
   border-color: #586875;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #586875;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #18262F;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #F5F7FA;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #18262F;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #586875;
   color: #F5F7FA;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #222E38 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #222E38 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #222E38 rgba(24, 38, 47, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(24, 38, 47, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #222E38;
   border-radius: 0px;
   border: 2px solid #18262F;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #2c3b48;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #18262F;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #18262F;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #18262F;
   color: #F5F7FA;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #213440;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #294151;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-solar-flare.rstheme
+++ b/inst/themes/base16/base16-solar-flare.rstheme
@@ -18,26 +18,26 @@
   color: #F5F7FA;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #18262F;
   color: #F5F7FA;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #18262F;
   color: #F5F7FA;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #18262F;
   color: #F5F7FA;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #F5F7FA;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #222E38 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #85939E;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #586875 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #F5F7FA;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #222E38 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #586875 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #F5F7FA !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #586875 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #D73C9A;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #586875 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #18262F !important;
   color: #F5F7FA !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #F5F7FA !important;
   background: #586875 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #586875;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #586875;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #18262F;
   color: #F5F7FA;
   border-color: #586875;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #586875;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #18262F;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #F5F7FA;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #18262F;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #586875;
   color: #F5F7FA;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #222E38 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #222E38 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #222E38 rgba(24, 38, 47, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(24, 38, 47, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #222E38;
   border-radius: 0px;
   border: 2px solid #18262F;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #2c3b48;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #18262F;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #18262F;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #18262F;
   color: #F5F7FA;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #213440;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #294151;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-solarized-dark.rstheme
+++ b/inst/themes/base16/base16-solarized-dark.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Solarized Dark {rsthemes} */
 /* Solarized Dark by Ethan Schoonover (http://ethanschoonover.com/solarized) */
@@ -18,26 +18,26 @@
   color: #fdf6e3;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #002b36;
   color: #fdf6e3;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #002b36;
   color: #fdf6e3;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #002b36;
   color: #fdf6e3;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #fdf6e3;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #073642 !important;
   color: #fdf6e3 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #073642 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #073642;
   border-color: #002b36;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #002b36;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #073642 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #839496;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #586e75 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #fdf6e3;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #073642 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #586e75 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #fdf6e3 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #586e75 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d33682;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #586e75 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #002b36 !important;
   color: #fdf6e3 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #fdf6e3 !important;
   background: #586e75 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #586e75;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #586e75;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #002b36;
   color: #fdf6e3;
   border-color: #586e75;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #586e75;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #002b36;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #fdf6e3;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #002b36;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #586e75;
   color: #fdf6e3;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #073642 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #073642 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #073642 rgba(0, 43, 54, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(0, 43, 54, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #073642;
   border-radius: 0px;
   border: 2px solid #002b36;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #094959;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #002b36;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #002b36;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #002b36;
   color: #fdf6e3;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #003f50;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #005469;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-solarized-dark.rstheme
+++ b/inst/themes/base16/base16-solarized-dark.rstheme
@@ -18,26 +18,26 @@
   color: #fdf6e3;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #002b36;
   color: #fdf6e3;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #002b36;
   color: #fdf6e3;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #002b36;
   color: #fdf6e3;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #fdf6e3;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #073642 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #839496;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #586e75 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #fdf6e3;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #073642 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #586e75 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #fdf6e3 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #586e75 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d33682;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #586e75 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #002b36 !important;
   color: #fdf6e3 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #fdf6e3 !important;
   background: #586e75 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #586e75;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #586e75;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #002b36;
   color: #fdf6e3;
   border-color: #586e75;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #586e75;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #002b36;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #fdf6e3;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #002b36;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #586e75;
   color: #fdf6e3;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #073642 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #073642 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #073642 rgba(0, 43, 54, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(0, 43, 54, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #073642;
   border-radius: 0px;
   border: 2px solid #002b36;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #094959;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #002b36;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #002b36;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #002b36;
   color: #fdf6e3;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #003f50;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #005469;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-solarized-light.rstheme
+++ b/inst/themes/base16/base16-solarized-light.rstheme
@@ -18,35 +18,35 @@
   color: #002b36;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #fdf6e3;
   color: #002b36;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #fdf6e3;
   color: #002b36;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #fdf6e3 !important;
   color: #002b36 !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table {
+body .ace_editor_theme table {
   background-color: #fdf6e3 !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
+body .ace_editor_theme table thead > tr > th {
   background-color: #fdf6e3 !important;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme a {
+body.ace_editor_theme a {
   color: #002b36 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-light-menus .gwt-Label {
+body .gwt-Label {
   color: #002b36;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   background: #fdf6e3 !important;
   color: #002b36 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
+body .rstudio-themes-default .rstudio-themes-background {
   background: #fdf6e3 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+body .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+body .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #fdf6e3;
   border-color: #fdf6e3;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
+body .rstudio-themes-default .rstudio-themes-border {
   border-color: #fdf6e3;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #93a1a1 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #839496;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-default .rstheme_center,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #eee8d5 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #586e75;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #93a1a1 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #eee8d5 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #002b36 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
+body .search, body.rstudio-themes-default-menus .search {
   /* search */
   background: #eee8d5 !important;
 }
 
-.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d33682;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
+.rstheme_secondaryToolbar, body .dataGridHeader {
   background: #eee8d5 !important;
 }
 
 /* menu background */
-.rstudio-themes-light-menus .popupMiddleCenter,
-.rstudio-themes-light-menus .menuPopupMiddleCenter,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #fdf6e3 !important;
   color: #002b36 !important;
 }
 
-.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #002b36 !important;
   background: #93a1a1 !important;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #93a1a1;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #93a1a1;
 }
 
-.rstudio-themes-light-menus .popupContent {
+body .popupContent {
   background: #fdf6e3;
   color: #002b36;
   border-color: #93a1a1;
 }
 
-.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #93a1a1;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #fdf6e3;
   padding: 2px;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #002b36;
   border: 0;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #fdf6e3;
 }
 
-.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #93a1a1;
   color: #002b36;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #93a1a1 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #93a1a1 !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-light-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
+body, body .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #eee8d5 rgba(253, 246, 227, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(253, 246, 227, 0.5);
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #eee8d5;
   border-radius: 0px;
   border: 2px solid #fdf6e3;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #e7dec3;
 }
 
@@ -529,49 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #fdf6e3;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #fdf6e3;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #fdf6e3;
   color: #002b36;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #fbeecb;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #fae7b3;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-solarized-light.rstheme
+++ b/inst/themes/base16/base16-solarized-light.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Solarized Light {rsthemes} */
 /* Solarized Light by Ethan Schoonover (http://ethanschoonover.com/solarized) */
@@ -18,35 +18,35 @@
   color: #002b36;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-light-menus.ace_editor_theme {
   background-color: #fdf6e3;
   color: #002b36;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #fdf6e3;
   color: #002b36;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-light-menus .ace_editor_theme {
   background-color: #fdf6e3 !important;
   color: #002b36 !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table {
+.rstudio-themes-light-menus .ace_editor_theme table {
   background-color: #fdf6e3 !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table thead > tr > th {
+.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
   background-color: #fdf6e3 !important;
 }
 
-.rstudio-themes-flat.ace_editor_theme a {
+.rstudio-themes-light-menus.ace_editor_theme a {
   color: #002b36 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-light-menus .gwt-Label {
   color: #002b36;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   background: #fdf6e3 !important;
   color: #002b36 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
   background: #fdf6e3 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #fdf6e3;
   border-color: #fdf6e3;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
   border-color: #fdf6e3;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #93a1a1 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #839496;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-default .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #eee8d5 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #586e75;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #93a1a1 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper {
   background: #eee8d5 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
   color: #002b36 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .search, .rstudio-themes-flat.rstudio-themes-default-menus .search {
+.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
   /* search */
   background: #eee8d5 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d33682;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
   background: #eee8d5 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-light-menus .popupMiddleCenter,
+.rstudio-themes-light-menus .menuPopupMiddleCenter,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter {
   background: #fdf6e3 !important;
   color: #002b36 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #002b36 !important;
   background: #93a1a1 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-light-menus .themedPopupPanel {
   border: solid 1px #93a1a1;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #93a1a1;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-light-menus .popupContent {
   background: #fdf6e3;
   color: #002b36;
   border-color: #93a1a1;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #93a1a1;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
   background: #fdf6e3;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
   background: #002b36;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #fdf6e3;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #93a1a1;
   color: #002b36;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #93a1a1 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #93a1a1 !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-light-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #eee8d5 rgba(253, 246, 227, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(253, 246, 227, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #eee8d5;
   border-radius: 0px;
   border: 2px solid #fdf6e3;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #e7dec3;
 }
 
@@ -529,35 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #fdf6e3;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #fdf6e3;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #fdf6e3;
   color: #002b36;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #fbeecb;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #fae7b3;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-spacemacs.rstheme
+++ b/inst/themes/base16/base16-spacemacs.rstheme
@@ -18,26 +18,26 @@
   color: #f8f8f8;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #1f2022;
   color: #f8f8f8;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #1f2022;
   color: #f8f8f8;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #1f2022;
   color: #f8f8f8;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #f8f8f8;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #282828 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #b8b8b8;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #444155 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f8f8f8;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #282828 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #444155 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #f8f8f8 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #444155 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #b03060;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #444155 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #1f2022 !important;
   color: #f8f8f8 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #f8f8f8 !important;
   background: #444155 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #444155;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #444155;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #1f2022;
   color: #f8f8f8;
   border-color: #444155;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #444155;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #1f2022;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #f8f8f8;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1f2022;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #444155;
   color: #f8f8f8;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #282828 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #282828 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #282828 rgba(31, 32, 34, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(31, 32, 34, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #282828;
   border-radius: 0px;
   border: 2px solid #1f2022;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #353535;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #1f2022;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #1f2022;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1f2022;
   color: #f8f8f8;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #2b2d2f;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #37393d;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-spacemacs.rstheme
+++ b/inst/themes/base16/base16-spacemacs.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Spacemacs {rsthemes} */
 /* Spacemacs by Nasser Alshammari (https://github.com/nashamri/spacemacs-theme) */
@@ -18,26 +18,26 @@
   color: #f8f8f8;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #1f2022;
   color: #f8f8f8;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #1f2022;
   color: #f8f8f8;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #1f2022;
   color: #f8f8f8;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #f8f8f8;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #282828 !important;
   color: #f8f8f8 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #282828 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #282828;
   border-color: #1f2022;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #1f2022;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #282828 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #b8b8b8;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #444155 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f8f8f8;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #282828 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #444155 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #f8f8f8 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #444155 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #b03060;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #444155 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #1f2022 !important;
   color: #f8f8f8 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #f8f8f8 !important;
   background: #444155 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #444155;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #444155;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #1f2022;
   color: #f8f8f8;
   border-color: #444155;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #444155;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #1f2022;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #f8f8f8;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1f2022;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #444155;
   color: #f8f8f8;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #282828 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #282828 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #282828 rgba(31, 32, 34, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(31, 32, 34, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #282828;
   border-radius: 0px;
   border: 2px solid #1f2022;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #353535;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #1f2022;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #1f2022;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1f2022;
   color: #f8f8f8;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #2b2d2f;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #37393d;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-summerfruit-dark.rstheme
+++ b/inst/themes/base16/base16-summerfruit-dark.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Summerfruit Dark {rsthemes} */
 /* Summerfruit Dark by Christopher Corley (http://christop.club/) */
@@ -18,26 +18,26 @@
   color: #FFFFFF;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #151515;
   color: #FFFFFF;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #151515;
   color: #FFFFFF;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #151515;
   color: #FFFFFF;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #FFFFFF;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #202020 !important;
   color: #FFFFFF !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #202020 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #202020;
   border-color: #151515;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #151515;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #202020 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #B0B0B0;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #303030 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #FFFFFF;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #202020 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #303030 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #FFFFFF !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #303030 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #CC6633;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #303030 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #151515 !important;
   color: #FFFFFF !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #FFFFFF !important;
   background: #303030 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #303030;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #303030;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #151515;
   color: #FFFFFF;
   border-color: #303030;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #303030;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #151515;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #FFFFFF;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #151515;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #303030;
   color: #FFFFFF;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #202020 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #202020 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #202020 rgba(21, 21, 21, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(21, 21, 21, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #202020;
   border-radius: 0px;
   border: 2px solid #151515;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #2d2d2d;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #151515;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #151515;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #151515;
   color: #FFFFFF;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #222222;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #2f2f2f;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-summerfruit-dark.rstheme
+++ b/inst/themes/base16/base16-summerfruit-dark.rstheme
@@ -18,26 +18,26 @@
   color: #FFFFFF;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #151515;
   color: #FFFFFF;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #151515;
   color: #FFFFFF;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #151515;
   color: #FFFFFF;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #FFFFFF;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #202020 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #B0B0B0;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #303030 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #FFFFFF;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #202020 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #303030 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #FFFFFF !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #303030 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #CC6633;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #303030 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #151515 !important;
   color: #FFFFFF !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #FFFFFF !important;
   background: #303030 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #303030;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #303030;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #151515;
   color: #FFFFFF;
   border-color: #303030;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #303030;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #151515;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #FFFFFF;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #151515;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #303030;
   color: #FFFFFF;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #202020 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #202020 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #202020 rgba(21, 21, 21, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(21, 21, 21, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #202020;
   border-radius: 0px;
   border: 2px solid #151515;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #2d2d2d;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #151515;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #151515;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #151515;
   color: #FFFFFF;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #222222;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #2f2f2f;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-summerfruit-light.rstheme
+++ b/inst/themes/base16/base16-summerfruit-light.rstheme
@@ -18,35 +18,35 @@
   color: #202020;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #FFFFFF;
   color: #202020;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #FFFFFF;
   color: #202020;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #FFFFFF !important;
   color: #202020 !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table {
+body .ace_editor_theme table {
   background-color: #FFFFFF !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
+body .ace_editor_theme table thead > tr > th {
   background-color: #FFFFFF !important;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme a {
+body.ace_editor_theme a {
   color: #202020 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-light-menus .gwt-Label {
+body .gwt-Label {
   color: #202020;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   background: #FFFFFF !important;
   color: #202020 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
+body .rstudio-themes-default .rstudio-themes-background {
   background: #FFFFFF !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+body .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+body .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #FFFFFF;
   border-color: #FFFFFF;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
+body .rstudio-themes-default .rstudio-themes-border {
   border-color: #FFFFFF;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #D0D0D0 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #B0B0B0;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-default .rstheme_center,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #E0E0E0 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #101010;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #D0D0D0 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #E0E0E0 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #202020 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
+body .search, body.rstudio-themes-default-menus .search {
   /* search */
   background: #E0E0E0 !important;
 }
 
-.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #CC6633;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
+.rstheme_secondaryToolbar, body .dataGridHeader {
   background: #E0E0E0 !important;
 }
 
 /* menu background */
-.rstudio-themes-light-menus .popupMiddleCenter,
-.rstudio-themes-light-menus .menuPopupMiddleCenter,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #FFFFFF !important;
   color: #202020 !important;
 }
 
-.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #202020 !important;
   background: #D0D0D0 !important;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #D0D0D0;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #D0D0D0;
 }
 
-.rstudio-themes-light-menus .popupContent {
+body .popupContent {
   background: #FFFFFF;
   color: #202020;
   border-color: #D0D0D0;
 }
 
-.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #D0D0D0;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #FFFFFF;
   padding: 2px;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #202020;
   border: 0;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #FFFFFF;
 }
 
-.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #D0D0D0;
   color: #202020;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #D0D0D0 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #D0D0D0 !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-light-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
+body, body .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #E0E0E0 rgba(255, 255, 255, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(255, 255, 255, 0.5);
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #E0E0E0;
   border-radius: 0px;
   border: 2px solid #FFFFFF;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: lightgray;
 }
 
@@ -529,49 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #FFFFFF;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #FFFFFF;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #FFFFFF;
   color: #202020;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #f2f2f2;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #e6e6e6;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-summerfruit-light.rstheme
+++ b/inst/themes/base16/base16-summerfruit-light.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Summerfruit Light {rsthemes} */
 /* Summerfruit Light by Christopher Corley (http://christop.club/) */
@@ -18,35 +18,35 @@
   color: #202020;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-light-menus.ace_editor_theme {
   background-color: #FFFFFF;
   color: #202020;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #FFFFFF;
   color: #202020;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-light-menus .ace_editor_theme {
   background-color: #FFFFFF !important;
   color: #202020 !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table {
+.rstudio-themes-light-menus .ace_editor_theme table {
   background-color: #FFFFFF !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table thead > tr > th {
+.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
   background-color: #FFFFFF !important;
 }
 
-.rstudio-themes-flat.ace_editor_theme a {
+.rstudio-themes-light-menus.ace_editor_theme a {
   color: #202020 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-light-menus .gwt-Label {
   color: #202020;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   background: #FFFFFF !important;
   color: #202020 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
   background: #FFFFFF !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #FFFFFF;
   border-color: #FFFFFF;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
   border-color: #FFFFFF;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #D0D0D0 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #B0B0B0;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-default .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #E0E0E0 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #101010;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #D0D0D0 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper {
   background: #E0E0E0 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
   color: #202020 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .search, .rstudio-themes-flat.rstudio-themes-default-menus .search {
+.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
   /* search */
   background: #E0E0E0 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #CC6633;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
   background: #E0E0E0 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-light-menus .popupMiddleCenter,
+.rstudio-themes-light-menus .menuPopupMiddleCenter,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter {
   background: #FFFFFF !important;
   color: #202020 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #202020 !important;
   background: #D0D0D0 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-light-menus .themedPopupPanel {
   border: solid 1px #D0D0D0;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #D0D0D0;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-light-menus .popupContent {
   background: #FFFFFF;
   color: #202020;
   border-color: #D0D0D0;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #D0D0D0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
   background: #FFFFFF;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
   background: #202020;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #FFFFFF;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #D0D0D0;
   color: #202020;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #D0D0D0 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #D0D0D0 !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-light-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #E0E0E0 rgba(255, 255, 255, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(255, 255, 255, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #E0E0E0;
   border-radius: 0px;
   border: 2px solid #FFFFFF;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: lightgray;
 }
 
@@ -529,35 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #FFFFFF;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #FFFFFF;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #FFFFFF;
   color: #202020;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #f2f2f2;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #e6e6e6;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-tomorrow-night.rstheme
+++ b/inst/themes/base16/base16-tomorrow-night.rstheme
@@ -18,26 +18,26 @@
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #1d1f21;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #1d1f21;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #1d1f21;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #ffffff;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #282a2e !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #b4b7b4;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #373b41 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #282a2e !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #373b41 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #ffffff !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #373b41 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #a3685a;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #373b41 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #1d1f21 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #ffffff !important;
   background: #373b41 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #373b41;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #373b41;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #1d1f21;
   color: #ffffff;
   border-color: #373b41;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #373b41;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #1d1f21;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #ffffff;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1d1f21;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #373b41;
   color: #ffffff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #282a2e !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #282a2e !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #282a2e rgba(29, 31, 33, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(29, 31, 33, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #282a2e;
   border-radius: 0px;
   border: 2px solid #1d1f21;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #34363c;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #1d1f21;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #1d1f21;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1d1f21;
   color: #ffffff;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #292c2f;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #35393c;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-tomorrow-night.rstheme
+++ b/inst/themes/base16/base16-tomorrow-night.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Tomorrow Night {rsthemes} */
 /* Tomorrow Night by Chris Kempson (http://chriskempson.com) */
@@ -18,26 +18,26 @@
   color: #ffffff;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #1d1f21;
   color: #ffffff;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #1d1f21;
   color: #ffffff;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #1d1f21;
   color: #ffffff;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #ffffff;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #282a2e !important;
   color: #ffffff !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #282a2e !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #282a2e;
   border-color: #1d1f21;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #1d1f21;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #282a2e !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #b4b7b4;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #373b41 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #282a2e !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #373b41 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #373b41 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #a3685a;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #373b41 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #1d1f21 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #ffffff !important;
   background: #373b41 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #373b41;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #373b41;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #1d1f21;
   color: #ffffff;
   border-color: #373b41;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #373b41;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #1d1f21;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #ffffff;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1d1f21;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #373b41;
   color: #ffffff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #282a2e !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #282a2e !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #282a2e rgba(29, 31, 33, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(29, 31, 33, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #282a2e;
   border-radius: 0px;
   border: 2px solid #1d1f21;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #34363c;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #1d1f21;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #1d1f21;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1d1f21;
   color: #ffffff;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #292c2f;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #35393c;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-tomorrow.rstheme
+++ b/inst/themes/base16/base16-tomorrow.rstheme
@@ -18,35 +18,35 @@
   color: #1d1f21;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #ffffff;
   color: #1d1f21;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #ffffff;
   color: #1d1f21;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #ffffff !important;
   color: #1d1f21 !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table {
+body .ace_editor_theme table {
   background-color: #ffffff !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
+body .ace_editor_theme table thead > tr > th {
   background-color: #ffffff !important;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme a {
+body.ace_editor_theme a {
   color: #1d1f21 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-light-menus .gwt-Label {
+body .gwt-Label {
   color: #1d1f21;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   background: #ffffff !important;
   color: #1d1f21 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
+body .rstudio-themes-default .rstudio-themes-background {
   background: #ffffff !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+body .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+body .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #ffffff;
   border-color: #ffffff;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
+body .rstudio-themes-default .rstudio-themes-border {
   border-color: #ffffff;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #d6d6d6 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #8e908c;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-default .rstheme_center,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #e0e0e0 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #4d4d4c;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #d6d6d6 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #e0e0e0 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #1d1f21 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
+body .search, body.rstudio-themes-default-menus .search {
   /* search */
   background: #e0e0e0 !important;
 }
 
-.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #a3685a;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
+.rstheme_secondaryToolbar, body .dataGridHeader {
   background: #e0e0e0 !important;
 }
 
 /* menu background */
-.rstudio-themes-light-menus .popupMiddleCenter,
-.rstudio-themes-light-menus .menuPopupMiddleCenter,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #ffffff !important;
   color: #1d1f21 !important;
 }
 
-.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #1d1f21 !important;
   background: #d6d6d6 !important;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #d6d6d6;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #d6d6d6;
 }
 
-.rstudio-themes-light-menus .popupContent {
+body .popupContent {
   background: #ffffff;
   color: #1d1f21;
   border-color: #d6d6d6;
 }
 
-.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #d6d6d6;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #ffffff;
   padding: 2px;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #1d1f21;
   border: 0;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #d6d6d6;
   color: #1d1f21;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #d6d6d6 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #d6d6d6 !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-light-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
+body, body .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #e0e0e0 rgba(255, 255, 255, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(255, 255, 255, 0.5);
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #e0e0e0;
   border-radius: 0px;
   border: 2px solid #ffffff;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: lightgray;
 }
 
@@ -529,49 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #ffffff;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #ffffff;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #ffffff;
   color: #1d1f21;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #f2f2f2;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #e6e6e6;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-tomorrow.rstheme
+++ b/inst/themes/base16/base16-tomorrow.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Tomorrow {rsthemes} */
 /* Tomorrow by Chris Kempson (http://chriskempson.com) */
@@ -18,35 +18,35 @@
   color: #1d1f21;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-light-menus.ace_editor_theme {
   background-color: #ffffff;
   color: #1d1f21;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #ffffff;
   color: #1d1f21;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-light-menus .ace_editor_theme {
   background-color: #ffffff !important;
   color: #1d1f21 !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table {
+.rstudio-themes-light-menus .ace_editor_theme table {
   background-color: #ffffff !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table thead > tr > th {
+.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
   background-color: #ffffff !important;
 }
 
-.rstudio-themes-flat.ace_editor_theme a {
+.rstudio-themes-light-menus.ace_editor_theme a {
   color: #1d1f21 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-light-menus .gwt-Label {
   color: #1d1f21;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   background: #ffffff !important;
   color: #1d1f21 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
   background: #ffffff !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #ffffff;
   border-color: #ffffff;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
   border-color: #ffffff;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #d6d6d6 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #8e908c;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-default .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #e0e0e0 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #4d4d4c;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #d6d6d6 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper {
   background: #e0e0e0 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
   color: #1d1f21 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .search, .rstudio-themes-flat.rstudio-themes-default-menus .search {
+.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
   /* search */
   background: #e0e0e0 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #a3685a;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
   background: #e0e0e0 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-light-menus .popupMiddleCenter,
+.rstudio-themes-light-menus .menuPopupMiddleCenter,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter {
   background: #ffffff !important;
   color: #1d1f21 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #1d1f21 !important;
   background: #d6d6d6 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-light-menus .themedPopupPanel {
   border: solid 1px #d6d6d6;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #d6d6d6;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-light-menus .popupContent {
   background: #ffffff;
   color: #1d1f21;
   border-color: #d6d6d6;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #d6d6d6;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
   background: #ffffff;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
   background: #1d1f21;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #d6d6d6;
   color: #1d1f21;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #d6d6d6 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #d6d6d6 !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-light-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #e0e0e0 rgba(255, 255, 255, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(255, 255, 255, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #e0e0e0;
   border-radius: 0px;
   border: 2px solid #ffffff;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: lightgray;
 }
 
@@ -529,35 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #ffffff;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #ffffff;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #ffffff;
   color: #1d1f21;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #f2f2f2;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #e6e6e6;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-twilight.rstheme
+++ b/inst/themes/base16/base16-twilight.rstheme
@@ -18,26 +18,26 @@
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #1e1e1e;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #1e1e1e;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #1e1e1e;
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #ffffff;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #323537 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #838184;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #464b50 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #323537 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #464b50 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #ffffff !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #464b50 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #9b703f;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #464b50 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #1e1e1e !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #ffffff !important;
   background: #464b50 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #464b50;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #464b50;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #1e1e1e;
   color: #ffffff;
   border-color: #464b50;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #464b50;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #1e1e1e;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #ffffff;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1e1e1e;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #464b50;
   color: #ffffff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #323537 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #323537 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #323537 rgba(30, 30, 30, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(30, 30, 30, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #323537;
   border-radius: 0px;
   border: 2px solid #1e1e1e;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #3e4244;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #1e1e1e;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #1e1e1e;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1e1e1e;
   color: #ffffff;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #2b2b2b;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #383838;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-twilight.rstheme
+++ b/inst/themes/base16/base16-twilight.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Twilight {rsthemes} */
 /* Twilight by David Hart (https://github.com/hartbit) */
@@ -18,26 +18,26 @@
   color: #ffffff;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #1e1e1e;
   color: #ffffff;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #1e1e1e;
   color: #ffffff;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #1e1e1e;
   color: #ffffff;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #ffffff;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #323537 !important;
   color: #ffffff !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #323537 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #323537;
   border-color: #1e1e1e;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #1e1e1e;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #323537 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #838184;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #464b50 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #323537 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #464b50 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #464b50 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #9b703f;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #464b50 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #1e1e1e !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #ffffff !important;
   background: #464b50 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #464b50;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #464b50;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #1e1e1e;
   color: #ffffff;
   border-color: #464b50;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #464b50;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #1e1e1e;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #ffffff;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1e1e1e;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #464b50;
   color: #ffffff;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #323537 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #323537 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #323537 rgba(30, 30, 30, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(30, 30, 30, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #323537;
   border-radius: 0px;
   border: 2px solid #1e1e1e;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #3e4244;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #1e1e1e;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #1e1e1e;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1e1e1e;
   color: #ffffff;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #2b2b2b;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #383838;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-unikitty-dark.rstheme
+++ b/inst/themes/base16/base16-unikitty-dark.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Unikitty Dark {rsthemes} */
 /* Unikitty Dark by Josh W Lewis (@joshwlewis) */
@@ -18,26 +18,26 @@
   color: #f5f4f7;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #2e2a31;
   color: #f5f4f7;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #2e2a31;
   color: #f5f4f7;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #2e2a31;
   color: #f5f4f7;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #f5f4f7;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #4a464d !important;
   color: #f5f4f7 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #4a464d !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #4a464d;
   border-color: #2e2a31;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #2e2a31;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #4a464d !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #9f9da2;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #666369 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f5f4f7;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #4a464d !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #666369 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #f5f4f7 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #666369 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #c720ca;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #666369 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #2e2a31 !important;
   color: #f5f4f7 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #f5f4f7 !important;
   background: #666369 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #666369;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #666369;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #2e2a31;
   color: #f5f4f7;
   border-color: #666369;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #666369;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #2e2a31;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #f5f4f7;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #2e2a31;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #666369;
   color: #f5f4f7;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #4a464d !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #4a464d !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #4a464d rgba(46, 42, 49, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(46, 42, 49, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #4a464d;
   border-radius: 0px;
   border: 2px solid #2e2a31;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #57525a;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #2e2a31;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #2e2a31;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #2e2a31;
   color: #f5f4f7;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #3b363f;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #48424c;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-unikitty-dark.rstheme
+++ b/inst/themes/base16/base16-unikitty-dark.rstheme
@@ -18,26 +18,26 @@
   color: #f5f4f7;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #2e2a31;
   color: #f5f4f7;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #2e2a31;
   color: #f5f4f7;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #2e2a31;
   color: #f5f4f7;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #f5f4f7;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #4a464d !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #9f9da2;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #666369 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #f5f4f7;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #4a464d !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #666369 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #f5f4f7 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #666369 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #c720ca;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #666369 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #2e2a31 !important;
   color: #f5f4f7 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #f5f4f7 !important;
   background: #666369 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #666369;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #666369;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #2e2a31;
   color: #f5f4f7;
   border-color: #666369;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #666369;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #2e2a31;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #f5f4f7;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #2e2a31;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #666369;
   color: #f5f4f7;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #4a464d !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #4a464d !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #4a464d rgba(46, 42, 49, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(46, 42, 49, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #4a464d;
   border-radius: 0px;
   border: 2px solid #2e2a31;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #57525a;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #2e2a31;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #2e2a31;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #2e2a31;
   color: #f5f4f7;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #3b363f;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #48424c;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-unikitty-light.rstheme
+++ b/inst/themes/base16/base16-unikitty-light.rstheme
@@ -18,35 +18,35 @@
   color: #322d34;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #ffffff;
   color: #322d34;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #ffffff;
   color: #322d34;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #ffffff !important;
   color: #322d34 !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table {
+body .ace_editor_theme table {
   background-color: #ffffff !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
+body .ace_editor_theme table thead > tr > th {
   background-color: #ffffff !important;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme a {
+body.ace_editor_theme a {
   color: #322d34 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-light-menus .gwt-Label {
+body .gwt-Label {
   color: #322d34;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   background: #ffffff !important;
   color: #322d34 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
+body .rstudio-themes-default .rstudio-themes-background {
   background: #ffffff !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+body .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+body .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #ffffff;
   border-color: #ffffff;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
+body .rstudio-themes-default .rstudio-themes-border {
   border-color: #ffffff;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #c4c3c5 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #a7a5a8;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-default .rstheme_center,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #e1e1e2 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #6c696e;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #c4c3c5 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #e1e1e2 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #322d34 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
+body .search, body.rstudio-themes-default-menus .search {
   /* search */
   background: #e1e1e2 !important;
 }
 
-.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #e013d0;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
+.rstheme_secondaryToolbar, body .dataGridHeader {
   background: #e1e1e2 !important;
 }
 
 /* menu background */
-.rstudio-themes-light-menus .popupMiddleCenter,
-.rstudio-themes-light-menus .menuPopupMiddleCenter,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #ffffff !important;
   color: #322d34 !important;
 }
 
-.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #322d34 !important;
   background: #c4c3c5 !important;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #c4c3c5;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #c4c3c5;
 }
 
-.rstudio-themes-light-menus .popupContent {
+body .popupContent {
   background: #ffffff;
   color: #322d34;
   border-color: #c4c3c5;
 }
 
-.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #c4c3c5;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #ffffff;
   padding: 2px;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #322d34;
   border: 0;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #c4c3c5;
   color: #322d34;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #c4c3c5 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #c4c3c5 !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-light-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
+body, body .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #e1e1e2 rgba(255, 255, 255, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(255, 255, 255, 0.5);
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #e1e1e2;
   border-radius: 0px;
   border: 2px solid #ffffff;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #d4d4d5;
 }
 
@@ -529,49 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #ffffff;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #ffffff;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #ffffff;
   color: #322d34;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #f2f2f2;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #e6e6e6;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-unikitty-light.rstheme
+++ b/inst/themes/base16/base16-unikitty-light.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Unikitty Light {rsthemes} */
 /* Unikitty Light by Josh W Lewis (@joshwlewis) */
@@ -18,35 +18,35 @@
   color: #322d34;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-light-menus.ace_editor_theme {
   background-color: #ffffff;
   color: #322d34;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #ffffff;
   color: #322d34;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-light-menus .ace_editor_theme {
   background-color: #ffffff !important;
   color: #322d34 !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table {
+.rstudio-themes-light-menus .ace_editor_theme table {
   background-color: #ffffff !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table thead > tr > th {
+.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
   background-color: #ffffff !important;
 }
 
-.rstudio-themes-flat.ace_editor_theme a {
+.rstudio-themes-light-menus.ace_editor_theme a {
   color: #322d34 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-light-menus .gwt-Label {
   color: #322d34;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   background: #ffffff !important;
   color: #322d34 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
   background: #ffffff !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #ffffff;
   border-color: #ffffff;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
   border-color: #ffffff;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #c4c3c5 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #a7a5a8;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-default .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #e1e1e2 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #6c696e;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #c4c3c5 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper {
   background: #e1e1e2 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
   color: #322d34 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .search, .rstudio-themes-flat.rstudio-themes-default-menus .search {
+.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
   /* search */
   background: #e1e1e2 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #e013d0;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
   background: #e1e1e2 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-light-menus .popupMiddleCenter,
+.rstudio-themes-light-menus .menuPopupMiddleCenter,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter {
   background: #ffffff !important;
   color: #322d34 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #322d34 !important;
   background: #c4c3c5 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-light-menus .themedPopupPanel {
   border: solid 1px #c4c3c5;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #c4c3c5;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-light-menus .popupContent {
   background: #ffffff;
   color: #322d34;
   border-color: #c4c3c5;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #c4c3c5;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
   background: #ffffff;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
   background: #322d34;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #c4c3c5;
   color: #322d34;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #c4c3c5 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #c4c3c5 !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-light-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #e1e1e2 rgba(255, 255, 255, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(255, 255, 255, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #e1e1e2;
   border-radius: 0px;
   border: 2px solid #ffffff;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #d4d4d5;
 }
 
@@ -529,35 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #ffffff;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #ffffff;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #ffffff;
   color: #322d34;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #f2f2f2;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #e6e6e6;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-woodland.rstheme
+++ b/inst/themes/base16/base16-woodland.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Woodland {rsthemes} */
 /* Woodland by Jay Cornwall (https://jcornwall.com) */
@@ -18,26 +18,26 @@
   color: #e4d4c8;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #231e18;
   color: #e4d4c8;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #231e18;
   color: #e4d4c8;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #231e18;
   color: #e4d4c8;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #e4d4c8;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #302b25 !important;
   color: #e4d4c8 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #302b25 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #302b25;
   border-color: #231e18;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #231e18;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #302b25 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #b4a490;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #48413a !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #e4d4c8;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #302b25 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #48413a !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #e4d4c8 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #48413a !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #b49368;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #48413a !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #231e18 !important;
   color: #e4d4c8 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #e4d4c8 !important;
   background: #48413a !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #48413a;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #48413a;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #231e18;
   color: #e4d4c8;
   border-color: #48413a;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #48413a;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #231e18;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #e4d4c8;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #231e18;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #48413a;
   color: #e4d4c8;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #302b25 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #302b25 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #302b25 rgba(35, 30, 24, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(35, 30, 24, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #302b25;
   border-radius: 0px;
   border: 2px solid #231e18;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #3e3830;
 }
 
@@ -499,35 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #231e18;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #231e18;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #231e18;
   color: #e4d4c8;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #322b22;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #41382d;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/base16/base16-woodland.rstheme
+++ b/inst/themes/base16/base16-woodland.rstheme
@@ -18,26 +18,26 @@
   color: #e4d4c8;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #231e18;
   color: #e4d4c8;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #231e18;
   color: #e4d4c8;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #231e18;
   color: #e4d4c8;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #e4d4c8;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #302b25 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #b4a490;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #48413a !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #e4d4c8;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #302b25 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #48413a !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #e4d4c8 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #48413a !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #b49368;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #48413a !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #231e18 !important;
   color: #e4d4c8 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #e4d4c8 !important;
   background: #48413a !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #48413a;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #48413a;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #231e18;
   color: #e4d4c8;
   border-color: #48413a;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #48413a;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #231e18;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #e4d4c8;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #231e18;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #48413a;
   color: #e4d4c8;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #302b25 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #302b25 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #302b25 rgba(35, 30, 24, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(35, 30, 24, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #302b25;
   border-radius: 0px;
   border: 2px solid #231e18;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #3e3830;
 }
 
@@ -499,49 +499,49 @@ input#rstudio_command_palette_search {
   border-color: #231e18;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #231e18;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #231e18;
   color: #e4d4c8;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #322b22;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #41382d;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/fairyfloss.rstheme
+++ b/inst/themes/fairyfloss.rstheme
@@ -21,26 +21,26 @@
   color: #F8F8F2;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #5A5475;
   color: #F8F8F2;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #5A5475;
   color: #F8F8F2;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #5A5475;
   color: #F8F8F2;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #F8F8F2;
 }
 
@@ -297,112 +297,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #433f57 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: rgba(248, 248, 242, 0.6);
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #55506f !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #F8F8F2;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #433f57 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #55506f !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #F8F8F2 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #55506f !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #c2ffdf;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #55506f !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #5A5475 !important;
   color: #F8F8F2 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #F8F8F2 !important;
   background: #433f57 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px rgba(194, 255, 223, 0.4);
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px rgba(194, 255, 223, 0.4);
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #5A5475;
   color: #F8F8F2;
   border-color: rgba(194, 255, 223, 0.4);
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: rgba(194, 255, 223, 0.4);
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #5A5475;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #F8F8F2;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #5A5475;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #433f57;
   color: #F8F8F2;
 }
@@ -416,15 +416,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #433f57 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #433f57 !important;
 }
 
@@ -446,37 +446,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #55506f rgba(90, 84, 117, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(90, 84, 117, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #55506f;
   border-radius: 0px;
   border: 2px solid #5A5475;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #615a7e;
 }
 
@@ -491,26 +491,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-dark-menus .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
+body .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
   border-color: #383448 !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
   border-color: #383448;
 }
 
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
   border-color: #383448;
 }
 
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
   border-color: #5A5475 !important;
 }
 
 /* window containers */
-.rstudio-themes-dark-menus
+body
 > .rstudio-themes-dark
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -571,49 +571,49 @@ input#rstudio_command_palette_search {
   border-color: #5A5475;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #5A5475;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #5A5475;
   color: #F8F8F2;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #655f84;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #716993;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/fairyfloss.rstheme
+++ b/inst/themes/fairyfloss.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: Fairyfloss {rsthemes} */
 /* rs-theme-is-dark: TRUE */
@@ -21,26 +21,26 @@
   color: #F8F8F2;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #5A5475;
   color: #F8F8F2;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #5A5475;
   color: #F8F8F2;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #5A5475;
   color: #F8F8F2;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #F8F8F2;
 }
 
@@ -275,134 +275,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #383448 !important;
   color: #F8F8F2 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #383448 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #383448;
   border-color: #5A5475;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #5A5475;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #433f57 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: rgba(248, 248, 242, 0.6);
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #55506f !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #F8F8F2;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #433f57 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #55506f !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #F8F8F2 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #55506f !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #c2ffdf;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #55506f !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #5A5475 !important;
   color: #F8F8F2 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #F8F8F2 !important;
   background: #433f57 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px rgba(194, 255, 223, 0.4);
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px rgba(194, 255, 223, 0.4);
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #5A5475;
   color: #F8F8F2;
   border-color: rgba(194, 255, 223, 0.4);
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: rgba(194, 255, 223, 0.4);
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #5A5475;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #F8F8F2;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #5A5475;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #433f57;
   color: #F8F8F2;
 }
@@ -416,15 +416,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #433f57 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #433f57 !important;
 }
 
@@ -446,37 +446,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #55506f rgba(90, 84, 117, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(90, 84, 117, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #55506f;
   border-radius: 0px;
   border: 2px solid #5A5475;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #615a7e;
 }
 
@@ -491,26 +491,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-flat .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
+.rstudio-themes-dark-menus .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
   border-color: #383448 !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
   border-color: #383448;
 }
 
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
   border-color: #383448;
 }
 
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
   border-color: #5A5475 !important;
 }
 
 /* window containers */
-.rstudio-themes-flat
+.rstudio-themes-dark-menus
 > .rstudio-themes-dark
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -571,35 +571,49 @@ input#rstudio_command_palette_search {
   border-color: #5A5475;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #5A5475;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #5A5475;
   color: #F8F8F2;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #655f84;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #716993;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/flat-white.rstheme
+++ b/inst/themes/flat-white.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: Flat White {rsthemes} */
 /* rs-theme-is-dark: FALSE */
@@ -23,35 +23,35 @@
   color: #605a52;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-light-menus.ace_editor_theme {
   background-color: #f7f3ee;
   color: #605a52;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #f7f3ee;
   color: #605a52;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-light-menus .ace_editor_theme {
   background-color: #f7f3ee !important;
   color: #605a52 !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table {
+.rstudio-themes-light-menus .ace_editor_theme table {
   background-color: #f7f3ee !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table thead > tr > th {
+.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
   background-color: #f7f3ee !important;
 }
 
-.rstudio-themes-flat.ace_editor_theme a {
+.rstudio-themes-light-menus.ace_editor_theme a {
   color: #605a52 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-light-menus .gwt-Label {
   color: #605a52;
 }
 
@@ -316,148 +316,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   background: #e4ddd2 !important;
   color: #605a52 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
   background: #e4ddd2 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #e4ddd2;
   border-color: #f7f3ee;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
   border-color: #f7f3ee;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #e4ddd2 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #93836c;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-default .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #f1ece4 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #605a52;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #e4ddd2 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper {
   background: #f1ece4 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
   color: #605a52 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .search, .rstudio-themes-flat.rstudio-themes-default-menus .search {
+.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
   /* search */
   background: #f1ece4 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #6a4dff;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
   background: #f1ece4 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-light-menus .popupMiddleCenter,
+.rstudio-themes-light-menus .menuPopupMiddleCenter,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter {
   background: #f7f3ee !important;
   color: #605a52 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #605a52 !important;
   background: rgba(106, 77, 255, 0.2) !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-light-menus .themedPopupPanel {
   border: solid 1px rgba(106, 77, 255, 0.4);
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px rgba(106, 77, 255, 0.4);
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-light-menus .popupContent {
   background: #f7f3ee;
   color: #605a52;
   border-color: rgba(106, 77, 255, 0.4);
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: rgba(106, 77, 255, 0.4);
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
   background: #f7f3ee;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
   background: #605a52;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #f7f3ee;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: rgba(106, 77, 255, 0.2);
   color: #605a52;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #e4ddd2 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #e4ddd2 !important;
 }
 
@@ -479,36 +479,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-light-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #f1ece4 rgba(247, 243, 238, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(247, 243, 238, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #f1ece4;
   border-radius: 0px;
   border: 2px solid #f7f3ee;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #e8e0d4;
 }
 
@@ -579,39 +579,39 @@ table.rstheme_tabLayoutCenter .gwt-Label,
   background-color: #dcd3c6;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-border,
-.rstudio-themes-flat .windowframe > div:last-child,
-.rstudio-themes-flat .rstudio-themes-default .rstheme_toolbarWrapper,
-.rstudio-themes-flat .rstudio-themes-default .rstheme_secondaryToolbar,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanel > div > div.gwt-TabLayoutPanelTabs {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border,
+.rstudio-themes-light-menus .windowframe > div:last-child,
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_toolbarWrapper,
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_secondaryToolbar,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanel > div > div.gwt-TabLayoutPanelTabs {
   border-color: #e4ddd2 !important;
 }
 
 /* splitters */
-.rstudio-themes-flat > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
+.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
   border-color: transparent;
 }
 
-.rstudio-themes-flat > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   border-color: transparent;
 }
 
-.rstudio-themes-flat > .rstudio-themes-default .gwt-SplitLayoutPanel td {
+.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel td {
   border-color: transparent;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanel > div > div.gwt-TabLayoutPanelTabs {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanel > div > div.gwt-TabLayoutPanelTabs {
   border-color: #dcd3c6;
 }
 
-.rstudio-themes-flat .rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstheme_tabLayoutCenter,
+.rstudio-themes-light-menus .rstheme_tabLayoutCenter {
   border-color: #e4ddd2 !important;
   margin-left: 1px;
   margin-top: 1px;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTab-selected .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTab-selected .rstheme_tabLayoutCenter {
   box-shadow: 2px 0 0 #CF9A4F inset;
   border-radius: 0 !important;
   border-top: solid 1px #dcd3c6 !important;
@@ -620,11 +620,11 @@ table.rstheme_tabLayoutCenter .gwt-Label,
   margin-left: 0 !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTab:not(.gwt-TabLayoutPanelTab-selected) .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTab:not(.gwt-TabLayoutPanelTab-selected) .rstheme_tabLayoutCenter {
   border-bottom: solid 2px #dcd3c6 !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanel > div:last-child {
+.rstudio-themes-light-menus .gwt-TabLayoutPanel > div:last-child {
   border-left: solid 1px #dcd3c6 !important;
   border-right: solid 1px #dcd3c6 !important;
 }
@@ -645,35 +645,49 @@ input#rstudio_command_palette_search {
   border-color: #f7f3ee;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #f7f3ee;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #f7f3ee;
   color: #605a52;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #efe7dc;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #e7dbcb;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 
@@ -2827,123 +2841,171 @@ input#rstudio_command_palette_search {
   background-color: #eeeeee;
 }
 
-.rstudio-themes-flat [id^="rstudio_dialog"],
-.rstudio-themes-flat :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-flat .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-flat .dialogTopCenter,
-.rstudio-themes-flat .dialogTop,
-.rstudio-themes-flat .dialogMiddle,
-.rstudio-themes-flat .dataGridHeader {
+.rstudio-themes-light-menus [id^="rstudio_dialog"],
+.rstudio-themes-light-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+.rstudio-themes-light-menus .dialogTopCenter,
+.rstudio-themes-light-menus .dialogTop,
+.rstudio-themes-light-menus .dialogMiddle,
+.rstudio-themes-light-menus .dataGridHeader,
+.rstudio-themes-dark-menus [id^="rstudio_dialog"],
+.rstudio-themes-dark-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+.rstudio-themes-dark-menus .dialogTopCenter,
+.rstudio-themes-dark-menus .dialogTop,
+.rstudio-themes-dark-menus .dialogMiddle,
+.rstudio-themes-dark-menus .dataGridHeader {
   background: #f7f3ee !important;
   color: #605a52 !important;
 }
 
-.rstudio-themes-flat .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-flat .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
+.rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
+.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table,
+.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
   background: #f7f3ee !important;
   color: #605a52 !important;
   border-color: #f7f3ee !important;
 }
 
-.rstudio-themes-flat .dialogContent label.gwt-Label,
-.rstudio-themes-flat .dialogContent .gwt-RadioButton ~ * {
+.rstudio-themes-light-menus .dialogContent label.gwt-Label,
+.rstudio-themes-light-menus .dialogContent .gwt-RadioButton ~ *,
+.rstudio-themes-dark-menus .dialogContent label.gwt-Label,
+.rstudio-themes-dark-menus .dialogContent .gwt-RadioButton ~ * {
   color: #93836c !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
   color: #6a4dff !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_dialog"],
-.rstudio-themes-flat .dialogTop .dialogTopCenter,
-.rstudio-themes-flat .gwt-DialogBox-ModalDialog,
-.rstudio-themes-flat .dataGridHeader {
+.rstudio-themes-light-menus [id^="rstudio_dialog"],
+.rstudio-themes-light-menus .dialogTop .dialogTopCenter,
+.rstudio-themes-light-menus .gwt-DialogBox-ModalDialog,
+.rstudio-themes-light-menus .dataGridHeader,
+.rstudio-themes-dark-menus [id^="rstudio_dialog"],
+.rstudio-themes-dark-menus .dialogTop .dialogTopCenter,
+.rstudio-themes-dark-menus .gwt-DialogBox-ModalDialog,
+.rstudio-themes-dark-menus .dataGridHeader {
   /* outer border */
   border-color: #efe7dc !important;
 }
 
-.rstudio-themes-flat .dialogContent > table div,
-.rstudio-themes-flat .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
+.rstudio-themes-light-menus .dialogContent > table div,
+.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
+.rstudio-themes-dark-menus .dialogContent > table div,
+.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
   border-color: #efe7dc;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelTab {
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab,
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab {
   border-color: #efe7dc !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelTab-selected div {
+.rstudio-themes-light-menus [id^="rstudio_label"][aria-selected="true"] div,
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab-selected div,
+.rstudio-themes-dark-menus [id^="rstudio_label"][aria-selected="true"] div,
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab-selected div {
   background-color: transparent !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-flat .dialogContent button table,
-.rstudio-themes-flat .dialogContent button:not(:hover) table > tbody > tr > td > div {
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table td,
+.rstudio-themes-light-menus .dialogContent button table,
+.rstudio-themes-light-menus .dialogContent button:not(:hover) table > tbody > tr > td > div,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table td,
+.rstudio-themes-dark-menus .dialogContent button table,
+.rstudio-themes-dark-menus .dialogContent button:not(:hover) table > tbody > tr > td > div {
   background: #f7f3ee !important;
   color: #605a52 !important;
   border: none !important;
   box-shadow: none !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
   /* Dialog options lists and tabs */
   background: #f7f3ee !important;
   color: #605a52 !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
   background-color: #e9e2ef !important;
   border-color: #e9e2ef !important;
   color: #605a52 !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #605a52 !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
   color: #605a52 !important;
 }
 
-.rstudio-themes-flat .dialogContent button {
+.rstudio-themes-light-menus .dialogContent button,
+.rstudio-themes-dark-menus .dialogContent button {
   border-width: 2px !important;
   border-style: solid !important;
   border-color: #efe7dc !important;
   border-radius: 3px !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-flat .dialogContent button:hover,
-.rstudio-themes-flat .dialogContent button:hover table,
-.rstudio-themes-flat .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-flat .dialogContent button:hover table > tbody > tr > td > div {
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table div,
+.rstudio-themes-light-menus .dialogContent button:hover,
+.rstudio-themes-light-menus .dialogContent button:hover table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+.rstudio-themes-light-menus .dialogContent button:hover table > tbody > tr > td > div,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table div,
+.rstudio-themes-dark-menus .dialogContent button:hover,
+.rstudio-themes-dark-menus .dialogContent button:hover table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+.rstudio-themes-dark-menus .dialogContent button:hover table > tbody > tr > td > div {
   color: #605a52 !important;
   background: #e4ddd2 !important;
   border-color: #efe7dc !important;
 }
 
-.rstudio-themes-flat .dialogContent input {
+.rstudio-themes-light-menus .dialogContent input,
+.rstudio-themes-dark-menus .dialogContent input {
   background: #e4ddd2 !important;
   color: #605a52 !important;
   border-color: #efe7dc !important;
 }
 
-.rstudio-themes-flat .dialogContent input[type="checkbox"] {
+.rstudio-themes-light-menus .dialogContent input[type="checkbox"],
+.rstudio-themes-dark-menus .dialogContent input[type="checkbox"] {
   background: white !important;
   color: #605a52 !important;
 }
 
-.rstudio-themes-flat .dialogContent input[type="checkbox"]:checked::before {
+.rstudio-themes-light-menus .dialogContent input[type="checkbox"]:checked::before,
+.rstudio-themes-dark-menus .dialogContent input[type="checkbox"]:checked::before {
   content: "\2713" !important;
   color: #605a52 !important;
   vertical-align: top;
@@ -2951,31 +3013,37 @@ input#rstudio_command_palette_search {
   font-weight: 600;
 }
 
-.rstudio-themes-flat .dialogContent select {
+.rstudio-themes-light-menus .dialogContent select,
+.rstudio-themes-dark-menus .dialogContent select {
   background: white !important;
   color: #605a52 !important;
 }
 
-.rstudio-themes-flat .rstudio-HyperlinkLabel {
+.rstudio-themes-light-menus .rstudio-HyperlinkLabel,
+.rstudio-themes-dark-menus .rstudio-HyperlinkLabel {
   color: #6a4dff;
 }
 
-.rstudio-themes-flat .search {
+.rstudio-themes-light-menus .search,
+.rstudio-themes-dark-menus .search {
   /* code search */
   background-color: #f7f3ee;
   color: #605a52;
 }
 
-.rstudio-themes-flat .search .rstheme_center img {
+.rstudio-themes-light-menus .search .rstheme_center img,
+.rstudio-themes-dark-menus .search .rstheme_center img {
   display: none;
 }
 
-.rstudio-themes-flat .search .rstheme_center::before {
+.rstudio-themes-light-menus .search .rstheme_center::before,
+.rstudio-themes-dark-menus .search .rstheme_center::before {
   content: '\27a0';
   color: #605a52;
 }
 
-.rstudio-themes-flat .search .rstheme_center > button::before {
+.rstudio-themes-light-menus .search .rstheme_center > button::before,
+.rstudio-themes-dark-menus .search .rstheme_center > button::before {
   content: '\2297';
   color: #605a52;
   position: relative;
@@ -2983,54 +3051,66 @@ input#rstudio_command_palette_search {
   font-size: 1.25em;
 }
 
-.rstudio-themes-flat .search .rstheme_center > button:hover {
+.rstudio-themes-light-menus .search .rstheme_center > button:hover,
+.rstudio-themes-dark-menus .search .rstheme_center > button:hover {
   background: unset !important;
   border: unset !important;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
   height: 40px !important;
   background: #e4ddd2;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
   padding-left: 20px;
   padding-right: 20px;
   height: 40px;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
   vertical-align: middle !important;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
   height: 40px !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
+.rstudio-themes-light-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
   border-color: #e4ddd2 !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
   display: none;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   display: inline-block;
   position: absolute !important;
   top: 0 !important;
   padding-left: 3px;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   padding-top: 5px;
 }
 
-.rstudio-themes-flat .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-flat .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
+.rstudio-themes-light-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
+.rstudio-themes-light-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
+.rstudio-themes-dark-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
   top: 38px !important;
 }
 
-.windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
+.rstudio-themes-light-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
+.rstudio-themes-dark-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
   height: 40px !important;
 }

--- a/inst/themes/flat-white.rstheme
+++ b/inst/themes/flat-white.rstheme
@@ -23,35 +23,35 @@
   color: #605a52;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #f7f3ee;
   color: #605a52;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #f7f3ee;
   color: #605a52;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #f7f3ee !important;
   color: #605a52 !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table {
+body .ace_editor_theme table {
   background-color: #f7f3ee !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
+body .ace_editor_theme table thead > tr > th {
   background-color: #f7f3ee !important;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme a {
+body.ace_editor_theme a {
   color: #605a52 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-light-menus .gwt-Label {
+body .gwt-Label {
   color: #605a52;
 }
 
@@ -316,148 +316,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   background: #e4ddd2 !important;
   color: #605a52 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
+body .rstudio-themes-default .rstudio-themes-background {
   background: #e4ddd2 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+body .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+body .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #e4ddd2;
   border-color: #f7f3ee;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
+body .rstudio-themes-default .rstudio-themes-border {
   border-color: #f7f3ee;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #e4ddd2 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #93836c;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-default .rstheme_center,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #f1ece4 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #605a52;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #e4ddd2 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #f1ece4 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #605a52 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
+body .search, body.rstudio-themes-default-menus .search {
   /* search */
   background: #f1ece4 !important;
 }
 
-.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #6a4dff;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
+.rstheme_secondaryToolbar, body .dataGridHeader {
   background: #f1ece4 !important;
 }
 
 /* menu background */
-.rstudio-themes-light-menus .popupMiddleCenter,
-.rstudio-themes-light-menus .menuPopupMiddleCenter,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #f7f3ee !important;
   color: #605a52 !important;
 }
 
-.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #605a52 !important;
   background: rgba(106, 77, 255, 0.2) !important;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px rgba(106, 77, 255, 0.4);
 }
 
-.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px rgba(106, 77, 255, 0.4);
 }
 
-.rstudio-themes-light-menus .popupContent {
+body .popupContent {
   background: #f7f3ee;
   color: #605a52;
   border-color: rgba(106, 77, 255, 0.4);
 }
 
-.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: rgba(106, 77, 255, 0.4);
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #f7f3ee;
   padding: 2px;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #605a52;
   border: 0;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #f7f3ee;
 }
 
-.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: rgba(106, 77, 255, 0.2);
   color: #605a52;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #e4ddd2 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #e4ddd2 !important;
 }
 
@@ -479,36 +479,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-light-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
+body, body .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #f1ece4 rgba(247, 243, 238, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(247, 243, 238, 0.5);
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #f1ece4;
   border-radius: 0px;
   border: 2px solid #f7f3ee;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #e8e0d4;
 }
 
@@ -579,39 +579,39 @@ table.rstheme_tabLayoutCenter .gwt-Label,
   background-color: #dcd3c6;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border,
-.rstudio-themes-light-menus .windowframe > div:last-child,
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_toolbarWrapper,
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_secondaryToolbar,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanel > div > div.gwt-TabLayoutPanelTabs {
+body .rstudio-themes-default .rstudio-themes-border,
+body .windowframe > div:last-child,
+body .rstudio-themes-default .rstheme_toolbarWrapper,
+body .rstudio-themes-default .rstheme_secondaryToolbar,
+body .rstudio-themes-default .gwt-TabLayoutPanel > div > div.gwt-TabLayoutPanelTabs {
   border-color: #e4ddd2 !important;
 }
 
 /* splitters */
-.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
+body > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
   border-color: transparent;
 }
 
-.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   border-color: transparent;
 }
 
-.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel td {
+body > .rstudio-themes-default .gwt-SplitLayoutPanel td {
   border-color: transparent;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanel > div > div.gwt-TabLayoutPanelTabs {
+body .rstudio-themes-default .gwt-TabLayoutPanel > div > div.gwt-TabLayoutPanelTabs {
   border-color: #dcd3c6;
 }
 
-.rstudio-themes-light-menus .rstheme_tabLayoutCenter,
-.rstudio-themes-light-menus .rstheme_tabLayoutCenter {
+body .rstheme_tabLayoutCenter,
+body .rstheme_tabLayoutCenter {
   border-color: #e4ddd2 !important;
   margin-left: 1px;
   margin-top: 1px;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTab-selected .rstheme_tabLayoutCenter {
+body .gwt-TabLayoutPanelTab-selected .rstheme_tabLayoutCenter {
   box-shadow: 2px 0 0 #CF9A4F inset;
   border-radius: 0 !important;
   border-top: solid 1px #dcd3c6 !important;
@@ -620,11 +620,11 @@ table.rstheme_tabLayoutCenter .gwt-Label,
   margin-left: 0 !important;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTab:not(.gwt-TabLayoutPanelTab-selected) .rstheme_tabLayoutCenter {
+body .gwt-TabLayoutPanelTab:not(.gwt-TabLayoutPanelTab-selected) .rstheme_tabLayoutCenter {
   border-bottom: solid 2px #dcd3c6 !important;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanel > div:last-child {
+body .gwt-TabLayoutPanel > div:last-child {
   border-left: solid 1px #dcd3c6 !important;
   border-right: solid 1px #dcd3c6 !important;
 }
@@ -645,49 +645,49 @@ input#rstudio_command_palette_search {
   border-color: #f7f3ee;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #f7f3ee;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #f7f3ee;
   color: #605a52;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #efe7dc;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #e7dbcb;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 
@@ -2841,171 +2841,171 @@ input#rstudio_command_palette_search {
   background-color: #eeeeee;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_dialog"],
-.rstudio-themes-light-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-light-menus .dialogTopCenter,
-.rstudio-themes-light-menus .dialogTop,
-.rstudio-themes-light-menus .dialogMiddle,
-.rstudio-themes-light-menus .dataGridHeader,
-.rstudio-themes-dark-menus [id^="rstudio_dialog"],
-.rstudio-themes-dark-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-dark-menus .dialogTopCenter,
-.rstudio-themes-dark-menus .dialogTop,
-.rstudio-themes-dark-menus .dialogMiddle,
-.rstudio-themes-dark-menus .dataGridHeader {
+body [id^="rstudio_dialog"],
+body :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+body .dialogTopCenter,
+body .dialogTop,
+body .dialogMiddle,
+body .dataGridHeader,
+body [id^="rstudio_dialog"],
+body :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+body .dialogTopCenter,
+body .dialogTop,
+body .dialogMiddle,
+body .dataGridHeader {
   background: #f7f3ee !important;
   color: #605a52 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
-.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table,
-.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
+body .dialogContent > table:first-child:last-child :not(button) > table, body .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
+body .dialogContent > table:first-child:last-child :not(button) > table,
+body .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
   background: #f7f3ee !important;
   color: #605a52 !important;
   border-color: #f7f3ee !important;
 }
 
-.rstudio-themes-light-menus .dialogContent label.gwt-Label,
-.rstudio-themes-light-menus .dialogContent .gwt-RadioButton ~ *,
-.rstudio-themes-dark-menus .dialogContent label.gwt-Label,
-.rstudio-themes-dark-menus .dialogContent .gwt-RadioButton ~ * {
+body .dialogContent label.gwt-Label,
+body .dialogContent .gwt-RadioButton ~ *,
+body .dialogContent label.gwt-Label,
+body .dialogContent .gwt-RadioButton ~ * {
   color: #93836c !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
+body .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
+body .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
   color: #6a4dff !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_dialog"],
-.rstudio-themes-light-menus .dialogTop .dialogTopCenter,
-.rstudio-themes-light-menus .gwt-DialogBox-ModalDialog,
-.rstudio-themes-light-menus .dataGridHeader,
-.rstudio-themes-dark-menus [id^="rstudio_dialog"],
-.rstudio-themes-dark-menus .dialogTop .dialogTopCenter,
-.rstudio-themes-dark-menus .gwt-DialogBox-ModalDialog,
-.rstudio-themes-dark-menus .dataGridHeader {
+body [id^="rstudio_dialog"],
+body .dialogTop .dialogTopCenter,
+body .gwt-DialogBox-ModalDialog,
+body .dataGridHeader,
+body [id^="rstudio_dialog"],
+body .dialogTop .dialogTopCenter,
+body .gwt-DialogBox-ModalDialog,
+body .dataGridHeader {
   /* outer border */
   border-color: #efe7dc !important;
 }
 
-.rstudio-themes-light-menus .dialogContent > table div,
-.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
-.rstudio-themes-dark-menus .dialogContent > table div,
-.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
+body .dialogContent > table div,
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
+body .dialogContent > table div,
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
   border-color: #efe7dc;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab,
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab {
+body .dialogContent .gwt-TabLayoutPanelTab,
+body .dialogContent .gwt-TabLayoutPanelTab {
   border-color: #efe7dc !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab-selected div,
-.rstudio-themes-dark-menus [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab-selected div {
+body [id^="rstudio_label"][aria-selected="true"] div,
+body .dialogContent .gwt-TabLayoutPanelTab-selected div,
+body [id^="rstudio_label"][aria-selected="true"] div,
+body .dialogContent .gwt-TabLayoutPanelTab-selected div {
   background-color: transparent !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-light-menus .dialogContent button table,
-.rstudio-themes-light-menus .dialogContent button:not(:hover) table > tbody > tr > td > div,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-dark-menus .dialogContent button table,
-.rstudio-themes-dark-menus .dialogContent button:not(:hover) table > tbody > tr > td > div {
+body .dialogContent .gwt-Button-DialogAction table,
+body .dialogContent .gwt-Button-DialogAction table td,
+body .dialogContent button table,
+body .dialogContent button:not(:hover) table > tbody > tr > td > div,
+body .dialogContent .gwt-Button-DialogAction table,
+body .dialogContent .gwt-Button-DialogAction table td,
+body .dialogContent button table,
+body .dialogContent button:not(:hover) table > tbody > tr > td > div {
   background: #f7f3ee !important;
   color: #605a52 !important;
   border: none !important;
   box-shadow: none !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
+body .gwt-DialogBox .dialogContent [role="listbox"] > div,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [role="tablist"],
+body .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
+body .gwt-DialogBox .dialogContent [role="listbox"] > div,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [role="tablist"],
+body .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
   /* Dialog options lists and tabs */
   background: #f7f3ee !important;
   color: #605a52 !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
   background-color: #e9e2ef !important;
   border-color: #e9e2ef !important;
   color: #605a52 !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #605a52 !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
   color: #605a52 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent button,
-.rstudio-themes-dark-menus .dialogContent button {
+body .dialogContent button,
+body .dialogContent button {
   border-width: 2px !important;
   border-style: solid !important;
   border-color: #efe7dc !important;
   border-radius: 3px !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-light-menus .dialogContent button:hover,
-.rstudio-themes-light-menus .dialogContent button:hover table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-light-menus .dialogContent button:hover table > tbody > tr > td > div,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-dark-menus .dialogContent button:hover,
-.rstudio-themes-dark-menus .dialogContent button:hover table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-dark-menus .dialogContent button:hover table > tbody > tr > td > div {
+body .dialogContent .gwt-Button-DialogAction:hover table,
+body .dialogContent .gwt-Button-DialogAction:hover table div,
+body .dialogContent button:hover,
+body .dialogContent button:hover table,
+body .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+body .dialogContent button:hover table > tbody > tr > td > div,
+body .dialogContent .gwt-Button-DialogAction:hover table,
+body .dialogContent .gwt-Button-DialogAction:hover table div,
+body .dialogContent button:hover,
+body .dialogContent button:hover table,
+body .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+body .dialogContent button:hover table > tbody > tr > td > div {
   color: #605a52 !important;
   background: #e4ddd2 !important;
   border-color: #efe7dc !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input,
-.rstudio-themes-dark-menus .dialogContent input {
+body .dialogContent input,
+body .dialogContent input {
   background: #e4ddd2 !important;
   color: #605a52 !important;
   border-color: #efe7dc !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input[type="checkbox"],
-.rstudio-themes-dark-menus .dialogContent input[type="checkbox"] {
+body .dialogContent input[type="checkbox"],
+body .dialogContent input[type="checkbox"] {
   background: white !important;
   color: #605a52 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input[type="checkbox"]:checked::before,
-.rstudio-themes-dark-menus .dialogContent input[type="checkbox"]:checked::before {
+body .dialogContent input[type="checkbox"]:checked::before,
+body .dialogContent input[type="checkbox"]:checked::before {
   content: "\2713" !important;
   color: #605a52 !important;
   vertical-align: top;
@@ -3013,37 +3013,37 @@ input#rstudio_command_palette_search {
   font-weight: 600;
 }
 
-.rstudio-themes-light-menus .dialogContent select,
-.rstudio-themes-dark-menus .dialogContent select {
+body .dialogContent select,
+body .dialogContent select {
   background: white !important;
   color: #605a52 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-HyperlinkLabel,
-.rstudio-themes-dark-menus .rstudio-HyperlinkLabel {
+body .rstudio-HyperlinkLabel,
+body .rstudio-HyperlinkLabel {
   color: #6a4dff;
 }
 
-.rstudio-themes-light-menus .search,
-.rstudio-themes-dark-menus .search {
+body .search,
+body .search {
   /* code search */
   background-color: #f7f3ee;
   color: #605a52;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center img,
-.rstudio-themes-dark-menus .search .rstheme_center img {
+body .search .rstheme_center img,
+body .search .rstheme_center img {
   display: none;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center::before,
-.rstudio-themes-dark-menus .search .rstheme_center::before {
+body .search .rstheme_center::before,
+body .search .rstheme_center::before {
   content: '\27a0';
   color: #605a52;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center > button::before,
-.rstudio-themes-dark-menus .search .rstheme_center > button::before {
+body .search .rstheme_center > button::before,
+body .search .rstheme_center > button::before {
   content: '\2297';
   color: #605a52;
   position: relative;
@@ -3051,66 +3051,66 @@ input#rstudio_command_palette_search {
   font-size: 1.25em;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center > button:hover,
-.rstudio-themes-dark-menus .search .rstheme_center > button:hover {
+body .search .rstheme_center > button:hover,
+body .search .rstheme_center > button:hover {
   background: unset !important;
   border: unset !important;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
   height: 40px !important;
   background: #e4ddd2;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
   padding-left: 20px;
   padding-right: 20px;
   height: 40px;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
   vertical-align: middle !important;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
   height: 40px !important;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
+body .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
+body .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
   border-color: #e4ddd2 !important;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
   display: none;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   display: inline-block;
   position: absolute !important;
   top: 0 !important;
   padding-left: 3px;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   padding-top: 5px;
 }
 
-.rstudio-themes-light-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-light-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
-.rstudio-themes-dark-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
+body .windowframe .gwt-TabLayoutPanel > div:last-child,
+body .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
+body .windowframe .gwt-TabLayoutPanel > div:last-child,
+body .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
   top: 38px !important;
 }
 
-.rstudio-themes-light-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
-.rstudio-themes-dark-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
+body .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
+body .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
   height: 40px !important;
 }

--- a/inst/themes/github.rstheme
+++ b/inst/themes/github.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: GitHub {rsthemes} */
 /* rs-theme-is-dark: FALSE */
@@ -18,35 +18,35 @@
   color: #24292e;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-light-menus.ace_editor_theme {
   background-color: #FFFFFF;
   color: #24292e;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #FFFFFF;
   color: #24292e;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-light-menus .ace_editor_theme {
   background-color: #FFFFFF !important;
   color: #24292e !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table {
+.rstudio-themes-light-menus .ace_editor_theme table {
   background-color: #FFFFFF !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table thead > tr > th {
+.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
   background-color: #FFFFFF !important;
 }
 
-.rstudio-themes-flat.ace_editor_theme a {
+.rstudio-themes-light-menus.ace_editor_theme a {
   color: #24292e !important;
   font-weight: bold;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-light-menus .gwt-Label {
   color: #24292e;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   background: #FFFFFF !important;
   color: #24292e !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
   background: #FFFFFF !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #FFFFFF;
   border-color: #FFFFFF;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
   border-color: #FFFFFF;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #fafbfc !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #959da5;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-default .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #eff3f6 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #0366D6;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #fafbfc !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper {
   background: #eff3f6 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
   color: #6a737d !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .search, .rstudio-themes-flat.rstudio-themes-default-menus .search {
+.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
   /* search */
   background: #eff3f6 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #005cc5;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
   background: #eff3f6 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-light-menus .popupMiddleCenter,
+.rstudio-themes-light-menus .menuPopupMiddleCenter,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter {
   background: #FFFFFF !important;
   color: #24292e !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #24292e !important;
   background: rgba(3, 102, 214, 0.15) !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-light-menus .themedPopupPanel {
   border: solid 1px #ffeef0;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #ffeef0;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-light-menus .popupContent {
   background: #FFFFFF;
   color: #24292e;
   border-color: #ffeef0;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #ffeef0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
   background: #FFFFFF;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
   background: #24292e;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #FFFFFF;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: rgba(3, 102, 214, 0.15);
   color: #24292e;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #fafbfc !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #fafbfc !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-light-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #f6f8fa rgba(255, 255, 255, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(255, 255, 255, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #f6f8fa;
   border-radius: 0px;
   border: 2px solid #FFFFFF;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #e6ebf1;
 }
 
@@ -529,35 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #FFFFFF;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #FFFFFF;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #FFFFFF;
   color: #24292e;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #f2f2f2;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #e6e6e6;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/github.rstheme
+++ b/inst/themes/github.rstheme
@@ -18,35 +18,35 @@
   color: #24292e;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #FFFFFF;
   color: #24292e;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #FFFFFF;
   color: #24292e;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #FFFFFF !important;
   color: #24292e !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table {
+body .ace_editor_theme table {
   background-color: #FFFFFF !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
+body .ace_editor_theme table thead > tr > th {
   background-color: #FFFFFF !important;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme a {
+body.ace_editor_theme a {
   color: #24292e !important;
   font-weight: bold;
 }
 
-.rstudio-themes-light-menus .gwt-Label {
+body .gwt-Label {
   color: #24292e;
 }
 
@@ -311,148 +311,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   background: #FFFFFF !important;
   color: #24292e !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
+body .rstudio-themes-default .rstudio-themes-background {
   background: #FFFFFF !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+body .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+body .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #FFFFFF;
   border-color: #FFFFFF;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
+body .rstudio-themes-default .rstudio-themes-border {
   border-color: #FFFFFF;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #fafbfc !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #959da5;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-default .rstheme_center,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #eff3f6 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #0366D6;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #fafbfc !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #eff3f6 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #6a737d !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
+body .search, body.rstudio-themes-default-menus .search {
   /* search */
   background: #eff3f6 !important;
 }
 
-.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #005cc5;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
+.rstheme_secondaryToolbar, body .dataGridHeader {
   background: #eff3f6 !important;
 }
 
 /* menu background */
-.rstudio-themes-light-menus .popupMiddleCenter,
-.rstudio-themes-light-menus .menuPopupMiddleCenter,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #FFFFFF !important;
   color: #24292e !important;
 }
 
-.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #24292e !important;
   background: rgba(3, 102, 214, 0.15) !important;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #ffeef0;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #ffeef0;
 }
 
-.rstudio-themes-light-menus .popupContent {
+body .popupContent {
   background: #FFFFFF;
   color: #24292e;
   border-color: #ffeef0;
 }
 
-.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #ffeef0;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #FFFFFF;
   padding: 2px;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #24292e;
   border: 0;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #FFFFFF;
 }
 
-.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: rgba(3, 102, 214, 0.15);
   color: #24292e;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #fafbfc !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #fafbfc !important;
 }
 
@@ -474,36 +474,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-light-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
+body, body .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #f6f8fa rgba(255, 255, 255, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(255, 255, 255, 0.5);
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #f6f8fa;
   border-radius: 0px;
   border: 2px solid #FFFFFF;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #e6ebf1;
 }
 
@@ -529,49 +529,49 @@ input#rstudio_command_palette_search {
   border-color: #FFFFFF;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #FFFFFF;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #FFFFFF;
   color: #24292e;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #f2f2f2;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #e6e6e6;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/horizon-dark.rstheme
+++ b/inst/themes/horizon-dark.rstheme
@@ -17,26 +17,26 @@
   color: #8A8CA8;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #1a1c23;
   color: #8A8CA8;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #1a1c23;
   color: #8A8CA8;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #1a1c23;
   color: #8A8CA8;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #8A8CA8;
 }
 
@@ -293,112 +293,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #1a1a22 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: rgba(138, 140, 168, 0.6);
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #16161c !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #c4c6d4;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #1a1a22 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #16161c !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #6c6f93 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #16161c !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #fac29a;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #16161c !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #16161c !important;
   color: #c4c6d4 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #c4c6d4 !important;
   background: #232530 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #16161c;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #16161c;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #16161c;
   color: #c4c6d4;
   border-color: #16161c;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #16161c;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #16161c;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #c4c6d4;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #16161c;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #232530;
   color: #c4c6d4;
 }
@@ -412,15 +412,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #1a1a22 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #1a1a22 !important;
 }
 
@@ -442,37 +442,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #1c1e26 rgba(26, 28, 35, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(26, 28, 35, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #1c1e26;
   border-radius: 0px;
   border: 2px solid #1a1c23;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #272a35;
 }
 
@@ -487,26 +487,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-dark-menus .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
+body .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
   border-color: #16161c !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
   border-color: #16161c;
 }
 
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
   border-color: #16161c;
 }
 
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
   border-color: #1a1c23 !important;
 }
 
 /* window containers */
-.rstudio-themes-dark-menus
+body
 > .rstudio-themes-dark
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -555,12 +555,12 @@ table.rstheme_tabLayoutCenter .gwt-Label,
   border: none;
 }
 
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
+body .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
   box-shadow: 0 3px 0 #e95678 inset;
   border-radius: 0 !important;
 }
 
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter .gwt-Label {
+body .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter .gwt-Label {
   font-weight: 600;
 }
 
@@ -2697,275 +2697,275 @@ input#rstudio_command_palette_search {
   border-color: #1a1c23;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #1a1c23;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1a1c23;
   color: #8A8CA8;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #252832;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #303340;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
   height: 40px !important;
   background: #1a1a22;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
   padding-left: 20px;
   padding-right: 20px;
   height: 40px;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
   vertical-align: middle !important;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
   height: 40px !important;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
+body .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
+body .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
   border-color: #1a1a22 !important;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
   display: none;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   display: inline-block;
   position: absolute !important;
   top: 0 !important;
   padding-left: 3px;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   padding-top: 5px;
 }
 
-.rstudio-themes-light-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-light-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
-.rstudio-themes-dark-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
+body .windowframe .gwt-TabLayoutPanel > div:last-child,
+body .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
+body .windowframe .gwt-TabLayoutPanel > div:last-child,
+body .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
   top: 38px !important;
 }
 
-.rstudio-themes-light-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
-.rstudio-themes-dark-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
+body .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
+body .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
   height: 40px !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_dialog"],
-.rstudio-themes-light-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-light-menus .dialogTopCenter,
-.rstudio-themes-light-menus .dialogTop,
-.rstudio-themes-light-menus .dialogMiddle,
-.rstudio-themes-light-menus .dataGridHeader,
-.rstudio-themes-dark-menus [id^="rstudio_dialog"],
-.rstudio-themes-dark-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-dark-menus .dialogTopCenter,
-.rstudio-themes-dark-menus .dialogTop,
-.rstudio-themes-dark-menus .dialogMiddle,
-.rstudio-themes-dark-menus .dataGridHeader {
+body [id^="rstudio_dialog"],
+body :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+body .dialogTopCenter,
+body .dialogTop,
+body .dialogMiddle,
+body .dataGridHeader,
+body [id^="rstudio_dialog"],
+body :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+body .dialogTopCenter,
+body .dialogTop,
+body .dialogMiddle,
+body .dataGridHeader {
   background: #16161c !important;
   color: #acafc3 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
-.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table,
-.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
+body .dialogContent > table:first-child:last-child :not(button) > table, body .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
+body .dialogContent > table:first-child:last-child :not(button) > table,
+body .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
   background: #16161c !important;
   color: #acafc3 !important;
   border-color: #16161c !important;
 }
 
-.rstudio-themes-light-menus .dialogContent label.gwt-Label,
-.rstudio-themes-light-menus .dialogContent .gwt-RadioButton ~ *,
-.rstudio-themes-dark-menus .dialogContent label.gwt-Label,
-.rstudio-themes-dark-menus .dialogContent .gwt-RadioButton ~ * {
+body .dialogContent label.gwt-Label,
+body .dialogContent .gwt-RadioButton ~ *,
+body .dialogContent label.gwt-Label,
+body .dialogContent .gwt-RadioButton ~ * {
   color: #f09383 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
+body .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
+body .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
   color: #b877db !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_dialog"],
-.rstudio-themes-light-menus .dialogTop .dialogTopCenter,
-.rstudio-themes-light-menus .gwt-DialogBox-ModalDialog,
-.rstudio-themes-light-menus .dataGridHeader,
-.rstudio-themes-dark-menus [id^="rstudio_dialog"],
-.rstudio-themes-dark-menus .dialogTop .dialogTopCenter,
-.rstudio-themes-dark-menus .gwt-DialogBox-ModalDialog,
-.rstudio-themes-dark-menus .dataGridHeader {
+body [id^="rstudio_dialog"],
+body .dialogTop .dialogTopCenter,
+body .gwt-DialogBox-ModalDialog,
+body .dataGridHeader,
+body [id^="rstudio_dialog"],
+body .dialogTop .dialogTopCenter,
+body .gwt-DialogBox-ModalDialog,
+body .dataGridHeader {
   /* outer border */
   border-color: #21212a !important;
 }
 
-.rstudio-themes-light-menus .dialogContent > table div,
-.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
-.rstudio-themes-dark-menus .dialogContent > table div,
-.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
+body .dialogContent > table div,
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
+body .dialogContent > table div,
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
   border-color: #21212a;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab,
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab {
+body .dialogContent .gwt-TabLayoutPanelTab,
+body .dialogContent .gwt-TabLayoutPanelTab {
   border-color: #21212a !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab-selected div,
-.rstudio-themes-dark-menus [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab-selected div {
+body [id^="rstudio_label"][aria-selected="true"] div,
+body .dialogContent .gwt-TabLayoutPanelTab-selected div,
+body [id^="rstudio_label"][aria-selected="true"] div,
+body .dialogContent .gwt-TabLayoutPanelTab-selected div {
   background-color: transparent !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-light-menus .dialogContent button table,
-.rstudio-themes-light-menus .dialogContent button:not(:hover) table > tbody > tr > td > div,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-dark-menus .dialogContent button table,
-.rstudio-themes-dark-menus .dialogContent button:not(:hover) table > tbody > tr > td > div {
+body .dialogContent .gwt-Button-DialogAction table,
+body .dialogContent .gwt-Button-DialogAction table td,
+body .dialogContent button table,
+body .dialogContent button:not(:hover) table > tbody > tr > td > div,
+body .dialogContent .gwt-Button-DialogAction table,
+body .dialogContent .gwt-Button-DialogAction table td,
+body .dialogContent button table,
+body .dialogContent button:not(:hover) table > tbody > tr > td > div {
   background: #16161c !important;
   color: #acafc3 !important;
   border: none !important;
   box-shadow: none !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
+body .gwt-DialogBox .dialogContent [role="listbox"] > div,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [role="tablist"],
+body .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
+body .gwt-DialogBox .dialogContent [role="listbox"] > div,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [role="tablist"],
+body .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
   /* Dialog options lists and tabs */
   background: #16161c !important;
   color: #acafc3 !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
   background-color: #21212a !important;
   border-color: #21212a !important;
   color: #acafc3 !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #acafc3 !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
   color: #acafc3 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent button,
-.rstudio-themes-dark-menus .dialogContent button {
+body .dialogContent button,
+body .dialogContent button {
   border-width: 2px !important;
   border-style: solid !important;
   border-color: #21212a !important;
   border-radius: 3px !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-light-menus .dialogContent button:hover,
-.rstudio-themes-light-menus .dialogContent button:hover table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-light-menus .dialogContent button:hover table > tbody > tr > td > div,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-dark-menus .dialogContent button:hover,
-.rstudio-themes-dark-menus .dialogContent button:hover table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-dark-menus .dialogContent button:hover table > tbody > tr > td > div {
+body .dialogContent .gwt-Button-DialogAction:hover table,
+body .dialogContent .gwt-Button-DialogAction:hover table div,
+body .dialogContent button:hover,
+body .dialogContent button:hover table,
+body .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+body .dialogContent button:hover table > tbody > tr > td > div,
+body .dialogContent .gwt-Button-DialogAction:hover table,
+body .dialogContent .gwt-Button-DialogAction:hover table div,
+body .dialogContent button:hover,
+body .dialogContent button:hover table,
+body .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+body .dialogContent button:hover table > tbody > tr > td > div {
   color: #caccd8 !important;
   background: #2c2c39 !important;
   border-color: #21212a !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input,
-.rstudio-themes-dark-menus .dialogContent input {
+body .dialogContent input,
+body .dialogContent input {
   background: #16161c !important;
   color: #acafc3 !important;
   border-color: #21212a !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input[type="checkbox"],
-.rstudio-themes-dark-menus .dialogContent input[type="checkbox"] {
+body .dialogContent input[type="checkbox"],
+body .dialogContent input[type="checkbox"] {
   background: #21212a !important;
   color: #acafc3 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input[type="checkbox"]:checked::before,
-.rstudio-themes-dark-menus .dialogContent input[type="checkbox"]:checked::before {
+body .dialogContent input[type="checkbox"]:checked::before,
+body .dialogContent input[type="checkbox"]:checked::before {
   content: "\2713" !important;
   color: #acafc3 !important;
   vertical-align: top;
@@ -2973,37 +2973,37 @@ input#rstudio_command_palette_search {
   font-weight: 600;
 }
 
-.rstudio-themes-light-menus .dialogContent select,
-.rstudio-themes-dark-menus .dialogContent select {
+body .dialogContent select,
+body .dialogContent select {
   background: #21212a !important;
   color: #acafc3 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-HyperlinkLabel,
-.rstudio-themes-dark-menus .rstudio-HyperlinkLabel {
+body .rstudio-HyperlinkLabel,
+body .rstudio-HyperlinkLabel {
   color: #b877db;
 }
 
-.rstudio-themes-light-menus .search,
-.rstudio-themes-dark-menus .search {
+body .search,
+body .search {
   /* code search */
   background-color: #16161c;
   color: #acafc3;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center img,
-.rstudio-themes-dark-menus .search .rstheme_center img {
+body .search .rstheme_center img,
+body .search .rstheme_center img {
   display: none;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center::before,
-.rstudio-themes-dark-menus .search .rstheme_center::before {
+body .search .rstheme_center::before,
+body .search .rstheme_center::before {
   content: '\27a0';
   color: #acafc3;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center > button::before,
-.rstudio-themes-dark-menus .search .rstheme_center > button::before {
+body .search .rstheme_center > button::before,
+body .search .rstheme_center > button::before {
   content: '\2297';
   color: #acafc3;
   position: relative;
@@ -3011,8 +3011,8 @@ input#rstudio_command_palette_search {
   font-size: 1.25em;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center > button:hover,
-.rstudio-themes-dark-menus .search .rstheme_center > button:hover {
+body .search .rstheme_center > button:hover,
+body .search .rstheme_center > button:hover {
   background: unset !important;
   border: unset !important;
 }

--- a/inst/themes/horizon-dark.rstheme
+++ b/inst/themes/horizon-dark.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: Horizon Dark {rsthemes} */
 /* rs-theme-is-dark: TRUE */
@@ -17,26 +17,26 @@
   color: #8A8CA8;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #1a1c23;
   color: #8A8CA8;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #1a1c23;
   color: #8A8CA8;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #1a1c23;
   color: #8A8CA8;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #8A8CA8;
 }
 
@@ -271,134 +271,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #16161c !important;
   color: #acafc3 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #16161c !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #16161c;
   border-color: #1a1c23;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #1a1c23;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #1a1a22 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: rgba(138, 140, 168, 0.6);
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #16161c !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #c4c6d4;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #1a1a22 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #16161c !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #6c6f93 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #16161c !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #fac29a;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #16161c !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #16161c !important;
   color: #c4c6d4 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #c4c6d4 !important;
   background: #232530 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #16161c;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #16161c;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #16161c;
   color: #c4c6d4;
   border-color: #16161c;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #16161c;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #16161c;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #c4c6d4;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #16161c;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #232530;
   color: #c4c6d4;
 }
@@ -412,15 +412,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #1a1a22 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #1a1a22 !important;
 }
 
@@ -442,37 +442,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #1c1e26 rgba(26, 28, 35, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(26, 28, 35, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #1c1e26;
   border-radius: 0px;
   border: 2px solid #1a1c23;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #272a35;
 }
 
@@ -487,26 +487,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-flat .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
+.rstudio-themes-dark-menus .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
   border-color: #16161c !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
   border-color: #16161c;
 }
 
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
   border-color: #16161c;
 }
 
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
   border-color: #1a1c23 !important;
 }
 
 /* window containers */
-.rstudio-themes-flat
+.rstudio-themes-dark-menus
 > .rstudio-themes-dark
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -555,12 +555,12 @@ table.rstheme_tabLayoutCenter .gwt-Label,
   border: none;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
   box-shadow: 0 3px 0 #e95678 inset;
   border-radius: 0 !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter .gwt-Label {
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter .gwt-Label {
   font-weight: 600;
 }
 
@@ -2697,202 +2697,275 @@ input#rstudio_command_palette_search {
   border-color: #1a1c23;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #1a1c23;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1a1c23;
   color: #8A8CA8;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #252832;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #303340;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
   height: 40px !important;
   background: #1a1a22;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
   padding-left: 20px;
   padding-right: 20px;
   height: 40px;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
   vertical-align: middle !important;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
   height: 40px !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
+.rstudio-themes-light-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
   border-color: #1a1a22 !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
   display: none;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   display: inline-block;
   position: absolute !important;
   top: 0 !important;
   padding-left: 3px;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   padding-top: 5px;
 }
 
-.rstudio-themes-flat .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-flat .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
+.rstudio-themes-light-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
+.rstudio-themes-light-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
+.rstudio-themes-dark-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
   top: 38px !important;
 }
 
-.windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
+.rstudio-themes-light-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
+.rstudio-themes-dark-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
   height: 40px !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_dialog"],
-.rstudio-themes-flat :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-flat .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-flat .dialogTopCenter,
-.rstudio-themes-flat .dialogTop,
-.rstudio-themes-flat .dialogMiddle,
-.rstudio-themes-flat .dataGridHeader {
+.rstudio-themes-light-menus [id^="rstudio_dialog"],
+.rstudio-themes-light-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+.rstudio-themes-light-menus .dialogTopCenter,
+.rstudio-themes-light-menus .dialogTop,
+.rstudio-themes-light-menus .dialogMiddle,
+.rstudio-themes-light-menus .dataGridHeader,
+.rstudio-themes-dark-menus [id^="rstudio_dialog"],
+.rstudio-themes-dark-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+.rstudio-themes-dark-menus .dialogTopCenter,
+.rstudio-themes-dark-menus .dialogTop,
+.rstudio-themes-dark-menus .dialogMiddle,
+.rstudio-themes-dark-menus .dataGridHeader {
   background: #16161c !important;
   color: #acafc3 !important;
 }
 
-.rstudio-themes-flat .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-flat .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
+.rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
+.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table,
+.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
   background: #16161c !important;
   color: #acafc3 !important;
   border-color: #16161c !important;
 }
 
-.rstudio-themes-flat .dialogContent label.gwt-Label,
-.rstudio-themes-flat .dialogContent .gwt-RadioButton ~ * {
+.rstudio-themes-light-menus .dialogContent label.gwt-Label,
+.rstudio-themes-light-menus .dialogContent .gwt-RadioButton ~ *,
+.rstudio-themes-dark-menus .dialogContent label.gwt-Label,
+.rstudio-themes-dark-menus .dialogContent .gwt-RadioButton ~ * {
   color: #f09383 !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
   color: #b877db !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_dialog"],
-.rstudio-themes-flat .dialogTop .dialogTopCenter,
-.rstudio-themes-flat .gwt-DialogBox-ModalDialog,
-.rstudio-themes-flat .dataGridHeader {
+.rstudio-themes-light-menus [id^="rstudio_dialog"],
+.rstudio-themes-light-menus .dialogTop .dialogTopCenter,
+.rstudio-themes-light-menus .gwt-DialogBox-ModalDialog,
+.rstudio-themes-light-menus .dataGridHeader,
+.rstudio-themes-dark-menus [id^="rstudio_dialog"],
+.rstudio-themes-dark-menus .dialogTop .dialogTopCenter,
+.rstudio-themes-dark-menus .gwt-DialogBox-ModalDialog,
+.rstudio-themes-dark-menus .dataGridHeader {
   /* outer border */
   border-color: #21212a !important;
 }
 
-.rstudio-themes-flat .dialogContent > table div,
-.rstudio-themes-flat .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
+.rstudio-themes-light-menus .dialogContent > table div,
+.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
+.rstudio-themes-dark-menus .dialogContent > table div,
+.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
   border-color: #21212a;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelTab {
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab,
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab {
   border-color: #21212a !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelTab-selected div {
+.rstudio-themes-light-menus [id^="rstudio_label"][aria-selected="true"] div,
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab-selected div,
+.rstudio-themes-dark-menus [id^="rstudio_label"][aria-selected="true"] div,
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab-selected div {
   background-color: transparent !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-flat .dialogContent button table,
-.rstudio-themes-flat .dialogContent button:not(:hover) table > tbody > tr > td > div {
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table td,
+.rstudio-themes-light-menus .dialogContent button table,
+.rstudio-themes-light-menus .dialogContent button:not(:hover) table > tbody > tr > td > div,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table td,
+.rstudio-themes-dark-menus .dialogContent button table,
+.rstudio-themes-dark-menus .dialogContent button:not(:hover) table > tbody > tr > td > div {
   background: #16161c !important;
   color: #acafc3 !important;
   border: none !important;
   box-shadow: none !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
   /* Dialog options lists and tabs */
   background: #16161c !important;
   color: #acafc3 !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
   background-color: #21212a !important;
   border-color: #21212a !important;
   color: #acafc3 !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #acafc3 !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
   color: #acafc3 !important;
 }
 
-.rstudio-themes-flat .dialogContent button {
+.rstudio-themes-light-menus .dialogContent button,
+.rstudio-themes-dark-menus .dialogContent button {
   border-width: 2px !important;
   border-style: solid !important;
   border-color: #21212a !important;
   border-radius: 3px !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-flat .dialogContent button:hover,
-.rstudio-themes-flat .dialogContent button:hover table,
-.rstudio-themes-flat .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-flat .dialogContent button:hover table > tbody > tr > td > div {
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table div,
+.rstudio-themes-light-menus .dialogContent button:hover,
+.rstudio-themes-light-menus .dialogContent button:hover table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+.rstudio-themes-light-menus .dialogContent button:hover table > tbody > tr > td > div,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table div,
+.rstudio-themes-dark-menus .dialogContent button:hover,
+.rstudio-themes-dark-menus .dialogContent button:hover table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+.rstudio-themes-dark-menus .dialogContent button:hover table > tbody > tr > td > div {
   color: #caccd8 !important;
   background: #2c2c39 !important;
   border-color: #21212a !important;
 }
 
-.rstudio-themes-flat .dialogContent input {
+.rstudio-themes-light-menus .dialogContent input,
+.rstudio-themes-dark-menus .dialogContent input {
   background: #16161c !important;
   color: #acafc3 !important;
   border-color: #21212a !important;
 }
 
-.rstudio-themes-flat .dialogContent input[type="checkbox"] {
+.rstudio-themes-light-menus .dialogContent input[type="checkbox"],
+.rstudio-themes-dark-menus .dialogContent input[type="checkbox"] {
   background: #21212a !important;
   color: #acafc3 !important;
 }
 
-.rstudio-themes-flat .dialogContent input[type="checkbox"]:checked::before {
+.rstudio-themes-light-menus .dialogContent input[type="checkbox"]:checked::before,
+.rstudio-themes-dark-menus .dialogContent input[type="checkbox"]:checked::before {
   content: "\2713" !important;
   color: #acafc3 !important;
   vertical-align: top;
@@ -2900,31 +2973,37 @@ input#rstudio_command_palette_search {
   font-weight: 600;
 }
 
-.rstudio-themes-flat .dialogContent select {
+.rstudio-themes-light-menus .dialogContent select,
+.rstudio-themes-dark-menus .dialogContent select {
   background: #21212a !important;
   color: #acafc3 !important;
 }
 
-.rstudio-themes-flat .rstudio-HyperlinkLabel {
+.rstudio-themes-light-menus .rstudio-HyperlinkLabel,
+.rstudio-themes-dark-menus .rstudio-HyperlinkLabel {
   color: #b877db;
 }
 
-.rstudio-themes-flat .search {
+.rstudio-themes-light-menus .search,
+.rstudio-themes-dark-menus .search {
   /* code search */
   background-color: #16161c;
   color: #acafc3;
 }
 
-.rstudio-themes-flat .search .rstheme_center img {
+.rstudio-themes-light-menus .search .rstheme_center img,
+.rstudio-themes-dark-menus .search .rstheme_center img {
   display: none;
 }
 
-.rstudio-themes-flat .search .rstheme_center::before {
+.rstudio-themes-light-menus .search .rstheme_center::before,
+.rstudio-themes-dark-menus .search .rstheme_center::before {
   content: '\27a0';
   color: #acafc3;
 }
 
-.rstudio-themes-flat .search .rstheme_center > button::before {
+.rstudio-themes-light-menus .search .rstheme_center > button::before,
+.rstudio-themes-dark-menus .search .rstheme_center > button::before {
   content: '\2297';
   color: #acafc3;
   position: relative;
@@ -2932,7 +3011,8 @@ input#rstudio_command_palette_search {
   font-size: 1.25em;
 }
 
-.rstudio-themes-flat .search .rstheme_center > button:hover {
+.rstudio-themes-light-menus .search .rstheme_center > button:hover,
+.rstudio-themes-dark-menus .search .rstheme_center > button:hover {
   background: unset !important;
   border: unset !important;
 }

--- a/inst/themes/material-darker.rstheme
+++ b/inst/themes/material-darker.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: Material Darker {rsthemes} */
 /* rs-theme-is-dark: TRUE */
@@ -17,26 +17,26 @@
   color: #EEFFFF;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #212121;
   color: #EEFFFF;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #212121;
   color: #EEFFFF;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #212121;
   color: #EEFFFF;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #EEFFFF;
 }
 
@@ -271,134 +271,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #1e1e1e !important;
   color: #EEFFFF !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #1e1e1e !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #1e1e1e;
   border-color: #212121;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #212121;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #212121 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #616161;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #212121 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #EEFFFF;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #212121 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #212121 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #545454 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #212121 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #84FFFF;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #212121 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #2b2b2b !important;
   color: #EEFFFF !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #EEFFFF !important;
   background: #424242 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #212121;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #212121;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #2b2b2b;
   color: #EEFFFF;
   border-color: #212121;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #212121;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #2b2b2b;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #EEFFFF;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #2b2b2b;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #424242;
   color: #EEFFFF;
 }
@@ -412,15 +412,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #212121 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #212121 !important;
 }
 
@@ -442,37 +442,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #1c1c1c rgba(33, 33, 33, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(33, 33, 33, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #1c1c1c;
   border-radius: 0px;
   border: 2px solid #212121;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #292929;
 }
 
@@ -487,26 +487,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-flat .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
+.rstudio-themes-dark-menus .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
   border-color: #1e1e1e !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
   border-color: #1e1e1e;
 }
 
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
   border-color: #1e1e1e;
 }
 
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
   border-color: #212121 !important;
 }
 
 /* window containers */
-.rstudio-themes-flat
+.rstudio-themes-dark-menus
 > .rstudio-themes-dark
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -555,15 +555,16 @@ table.rstheme_tabLayoutCenter .gwt-Label,
   border: none;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected {
+  /* remove border from panes */
+}
+
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
   box-shadow: 0 -2px 0 #84FFFF inset;
   border-radius: 0 !important;
 }
 
-/* remove border from panes */
-.rstudio-themes-flat
-:-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
-> div:last-child {
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected .rstudio-themes-dark-menus :-webkit-any(.windowframe, .rstheme_minimizedWindowObject) > div:last-child {
   border-color: #1e1e1e !important;
 }
 
@@ -2700,202 +2701,275 @@ input#rstudio_command_palette_search {
   border-color: #212121;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #212121;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #212121;
   color: #EEFFFF;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #2e2e2e;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3b3b3b;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
   height: 40px !important;
   background: #212121;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
   padding-left: 20px;
   padding-right: 20px;
   height: 40px;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
   vertical-align: middle !important;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
   height: 40px !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
+.rstudio-themes-light-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
   border-color: #212121 !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
   display: none;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   display: inline-block;
   position: absolute !important;
   top: 0 !important;
   padding-left: 3px;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   padding-top: 5px;
 }
 
-.rstudio-themes-flat .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-flat .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
+.rstudio-themes-light-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
+.rstudio-themes-light-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
+.rstudio-themes-dark-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
   top: 38px !important;
 }
 
-.windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
+.rstudio-themes-light-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
+.rstudio-themes-dark-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
   height: 40px !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_dialog"],
-.rstudio-themes-flat :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-flat .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-flat .dialogTopCenter,
-.rstudio-themes-flat .dialogTop,
-.rstudio-themes-flat .dialogMiddle,
-.rstudio-themes-flat .dataGridHeader {
+.rstudio-themes-light-menus [id^="rstudio_dialog"],
+.rstudio-themes-light-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+.rstudio-themes-light-menus .dialogTopCenter,
+.rstudio-themes-light-menus .dialogTop,
+.rstudio-themes-light-menus .dialogMiddle,
+.rstudio-themes-light-menus .dataGridHeader,
+.rstudio-themes-dark-menus [id^="rstudio_dialog"],
+.rstudio-themes-dark-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+.rstudio-themes-dark-menus .dialogTopCenter,
+.rstudio-themes-dark-menus .dialogTop,
+.rstudio-themes-dark-menus .dialogMiddle,
+.rstudio-themes-dark-menus .dataGridHeader {
   background: #1e1e1e !important;
   color: #EEFFFF !important;
 }
 
-.rstudio-themes-flat .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-flat .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
+.rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
+.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table,
+.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
   background: #1e1e1e !important;
   color: #EEFFFF !important;
   border-color: #1e1e1e !important;
 }
 
-.rstudio-themes-flat .dialogContent label.gwt-Label,
-.rstudio-themes-flat .dialogContent .gwt-RadioButton ~ * {
+.rstudio-themes-light-menus .dialogContent label.gwt-Label,
+.rstudio-themes-light-menus .dialogContent .gwt-RadioButton ~ *,
+.rstudio-themes-dark-menus .dialogContent label.gwt-Label,
+.rstudio-themes-dark-menus .dialogContent .gwt-RadioButton ~ * {
   color: #65737E !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
   color: #84FFFF !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_dialog"],
-.rstudio-themes-flat .dialogTop .dialogTopCenter,
-.rstudio-themes-flat .gwt-DialogBox-ModalDialog,
-.rstudio-themes-flat .dataGridHeader {
+.rstudio-themes-light-menus [id^="rstudio_dialog"],
+.rstudio-themes-light-menus .dialogTop .dialogTopCenter,
+.rstudio-themes-light-menus .gwt-DialogBox-ModalDialog,
+.rstudio-themes-light-menus .dataGridHeader,
+.rstudio-themes-dark-menus [id^="rstudio_dialog"],
+.rstudio-themes-dark-menus .dialogTop .dialogTopCenter,
+.rstudio-themes-dark-menus .gwt-DialogBox-ModalDialog,
+.rstudio-themes-dark-menus .dataGridHeader {
   /* outer border */
   border-color: #2b2b2b !important;
 }
 
-.rstudio-themes-flat .dialogContent > table div,
-.rstudio-themes-flat .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
+.rstudio-themes-light-menus .dialogContent > table div,
+.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
+.rstudio-themes-dark-menus .dialogContent > table div,
+.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
   border-color: #2b2b2b;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelTab {
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab,
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab {
   border-color: #2b2b2b !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelTab-selected div {
+.rstudio-themes-light-menus [id^="rstudio_label"][aria-selected="true"] div,
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab-selected div,
+.rstudio-themes-dark-menus [id^="rstudio_label"][aria-selected="true"] div,
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab-selected div {
   background-color: transparent !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-flat .dialogContent button table,
-.rstudio-themes-flat .dialogContent button:not(:hover) table > tbody > tr > td > div {
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table td,
+.rstudio-themes-light-menus .dialogContent button table,
+.rstudio-themes-light-menus .dialogContent button:not(:hover) table > tbody > tr > td > div,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table td,
+.rstudio-themes-dark-menus .dialogContent button table,
+.rstudio-themes-dark-menus .dialogContent button:not(:hover) table > tbody > tr > td > div {
   background: #1e1e1e !important;
   color: #EEFFFF !important;
   border: none !important;
   box-shadow: none !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
   /* Dialog options lists and tabs */
   background: #1e1e1e !important;
   color: #EEFFFF !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
   background-color: #2b2b2b !important;
   border-color: #2b2b2b !important;
   color: #65737E !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #65737E !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
   color: #65737E !important;
 }
 
-.rstudio-themes-flat .dialogContent button {
+.rstudio-themes-light-menus .dialogContent button,
+.rstudio-themes-dark-menus .dialogContent button {
   border-width: 2px !important;
   border-style: solid !important;
   border-color: #2b2b2b !important;
   border-radius: 3px !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-flat .dialogContent button:hover,
-.rstudio-themes-flat .dialogContent button:hover table,
-.rstudio-themes-flat .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-flat .dialogContent button:hover table > tbody > tr > td > div {
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table div,
+.rstudio-themes-light-menus .dialogContent button:hover,
+.rstudio-themes-light-menus .dialogContent button:hover table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+.rstudio-themes-light-menus .dialogContent button:hover table > tbody > tr > td > div,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table div,
+.rstudio-themes-dark-menus .dialogContent button:hover,
+.rstudio-themes-dark-menus .dialogContent button:hover table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+.rstudio-themes-dark-menus .dialogContent button:hover table > tbody > tr > td > div {
   color: #65737E !important;
   background: #383838 !important;
   border-color: #2b2b2b !important;
 }
 
-.rstudio-themes-flat .dialogContent input {
+.rstudio-themes-light-menus .dialogContent input,
+.rstudio-themes-dark-menus .dialogContent input {
   background: #1e1e1e !important;
   color: #FFCB6B !important;
   border-color: #2b2b2b !important;
 }
 
-.rstudio-themes-flat .dialogContent input[type="checkbox"] {
+.rstudio-themes-light-menus .dialogContent input[type="checkbox"],
+.rstudio-themes-dark-menus .dialogContent input[type="checkbox"] {
   background: #2b2b2b !important;
   color: #EEFFFF !important;
 }
 
-.rstudio-themes-flat .dialogContent input[type="checkbox"]:checked::before {
+.rstudio-themes-light-menus .dialogContent input[type="checkbox"]:checked::before,
+.rstudio-themes-dark-menus .dialogContent input[type="checkbox"]:checked::before {
   content: "\2713" !important;
   color: #EEFFFF !important;
   vertical-align: top;
@@ -2903,31 +2977,37 @@ input#rstudio_command_palette_search {
   font-weight: 600;
 }
 
-.rstudio-themes-flat .dialogContent select {
+.rstudio-themes-light-menus .dialogContent select,
+.rstudio-themes-dark-menus .dialogContent select {
   background: #2b2b2b !important;
   color: #EEFFFF !important;
 }
 
-.rstudio-themes-flat .rstudio-HyperlinkLabel {
+.rstudio-themes-light-menus .rstudio-HyperlinkLabel,
+.rstudio-themes-dark-menus .rstudio-HyperlinkLabel {
   color: #84FFFF;
 }
 
-.rstudio-themes-flat .search {
+.rstudio-themes-light-menus .search,
+.rstudio-themes-dark-menus .search {
   /* code search */
   background-color: #1e1e1e;
   color: #EEFFFF;
 }
 
-.rstudio-themes-flat .search .rstheme_center img {
+.rstudio-themes-light-menus .search .rstheme_center img,
+.rstudio-themes-dark-menus .search .rstheme_center img {
   display: none;
 }
 
-.rstudio-themes-flat .search .rstheme_center::before {
+.rstudio-themes-light-menus .search .rstheme_center::before,
+.rstudio-themes-dark-menus .search .rstheme_center::before {
   content: '\27a0';
   color: #EEFFFF;
 }
 
-.rstudio-themes-flat .search .rstheme_center > button::before {
+.rstudio-themes-light-menus .search .rstheme_center > button::before,
+.rstudio-themes-dark-menus .search .rstheme_center > button::before {
   content: '\2297';
   color: #EEFFFF;
   position: relative;
@@ -2935,7 +3015,8 @@ input#rstudio_command_palette_search {
   font-size: 1.25em;
 }
 
-.rstudio-themes-flat .search .rstheme_center > button:hover {
+.rstudio-themes-light-menus .search .rstheme_center > button:hover,
+.rstudio-themes-dark-menus .search .rstheme_center > button:hover {
   background: unset !important;
   border: unset !important;
 }

--- a/inst/themes/material-darker.rstheme
+++ b/inst/themes/material-darker.rstheme
@@ -17,26 +17,26 @@
   color: #EEFFFF;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #212121;
   color: #EEFFFF;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #212121;
   color: #EEFFFF;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #212121;
   color: #EEFFFF;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #EEFFFF;
 }
 
@@ -293,112 +293,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #212121 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #616161;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #212121 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #EEFFFF;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #212121 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #212121 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #545454 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #212121 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #84FFFF;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #212121 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #2b2b2b !important;
   color: #EEFFFF !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #EEFFFF !important;
   background: #424242 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #212121;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #212121;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #2b2b2b;
   color: #EEFFFF;
   border-color: #212121;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #212121;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #2b2b2b;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #EEFFFF;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #2b2b2b;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #424242;
   color: #EEFFFF;
 }
@@ -412,15 +412,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #212121 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #212121 !important;
 }
 
@@ -442,37 +442,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #1c1c1c rgba(33, 33, 33, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(33, 33, 33, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #1c1c1c;
   border-radius: 0px;
   border: 2px solid #212121;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #292929;
 }
 
@@ -487,26 +487,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-dark-menus .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
+body .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
   border-color: #1e1e1e !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
   border-color: #1e1e1e;
 }
 
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
   border-color: #1e1e1e;
 }
 
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
   border-color: #212121 !important;
 }
 
 /* window containers */
-.rstudio-themes-dark-menus
+body
 > .rstudio-themes-dark
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -2701,275 +2701,275 @@ input#rstudio_command_palette_search {
   border-color: #212121;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #212121;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #212121;
   color: #EEFFFF;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #2e2e2e;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3b3b3b;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
   height: 40px !important;
   background: #212121;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
   padding-left: 20px;
   padding-right: 20px;
   height: 40px;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
   vertical-align: middle !important;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
   height: 40px !important;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
+body .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
+body .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
   border-color: #212121 !important;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
   display: none;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   display: inline-block;
   position: absolute !important;
   top: 0 !important;
   padding-left: 3px;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   padding-top: 5px;
 }
 
-.rstudio-themes-light-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-light-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
-.rstudio-themes-dark-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
+body .windowframe .gwt-TabLayoutPanel > div:last-child,
+body .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
+body .windowframe .gwt-TabLayoutPanel > div:last-child,
+body .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
   top: 38px !important;
 }
 
-.rstudio-themes-light-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
-.rstudio-themes-dark-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
+body .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
+body .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
   height: 40px !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_dialog"],
-.rstudio-themes-light-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-light-menus .dialogTopCenter,
-.rstudio-themes-light-menus .dialogTop,
-.rstudio-themes-light-menus .dialogMiddle,
-.rstudio-themes-light-menus .dataGridHeader,
-.rstudio-themes-dark-menus [id^="rstudio_dialog"],
-.rstudio-themes-dark-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-dark-menus .dialogTopCenter,
-.rstudio-themes-dark-menus .dialogTop,
-.rstudio-themes-dark-menus .dialogMiddle,
-.rstudio-themes-dark-menus .dataGridHeader {
+body [id^="rstudio_dialog"],
+body :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+body .dialogTopCenter,
+body .dialogTop,
+body .dialogMiddle,
+body .dataGridHeader,
+body [id^="rstudio_dialog"],
+body :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+body .dialogTopCenter,
+body .dialogTop,
+body .dialogMiddle,
+body .dataGridHeader {
   background: #1e1e1e !important;
   color: #EEFFFF !important;
 }
 
-.rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
-.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table,
-.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
+body .dialogContent > table:first-child:last-child :not(button) > table, body .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
+body .dialogContent > table:first-child:last-child :not(button) > table,
+body .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
   background: #1e1e1e !important;
   color: #EEFFFF !important;
   border-color: #1e1e1e !important;
 }
 
-.rstudio-themes-light-menus .dialogContent label.gwt-Label,
-.rstudio-themes-light-menus .dialogContent .gwt-RadioButton ~ *,
-.rstudio-themes-dark-menus .dialogContent label.gwt-Label,
-.rstudio-themes-dark-menus .dialogContent .gwt-RadioButton ~ * {
+body .dialogContent label.gwt-Label,
+body .dialogContent .gwt-RadioButton ~ *,
+body .dialogContent label.gwt-Label,
+body .dialogContent .gwt-RadioButton ~ * {
   color: #65737E !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
+body .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
+body .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
   color: #84FFFF !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_dialog"],
-.rstudio-themes-light-menus .dialogTop .dialogTopCenter,
-.rstudio-themes-light-menus .gwt-DialogBox-ModalDialog,
-.rstudio-themes-light-menus .dataGridHeader,
-.rstudio-themes-dark-menus [id^="rstudio_dialog"],
-.rstudio-themes-dark-menus .dialogTop .dialogTopCenter,
-.rstudio-themes-dark-menus .gwt-DialogBox-ModalDialog,
-.rstudio-themes-dark-menus .dataGridHeader {
+body [id^="rstudio_dialog"],
+body .dialogTop .dialogTopCenter,
+body .gwt-DialogBox-ModalDialog,
+body .dataGridHeader,
+body [id^="rstudio_dialog"],
+body .dialogTop .dialogTopCenter,
+body .gwt-DialogBox-ModalDialog,
+body .dataGridHeader {
   /* outer border */
   border-color: #2b2b2b !important;
 }
 
-.rstudio-themes-light-menus .dialogContent > table div,
-.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
-.rstudio-themes-dark-menus .dialogContent > table div,
-.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
+body .dialogContent > table div,
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
+body .dialogContent > table div,
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
   border-color: #2b2b2b;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab,
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab {
+body .dialogContent .gwt-TabLayoutPanelTab,
+body .dialogContent .gwt-TabLayoutPanelTab {
   border-color: #2b2b2b !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab-selected div,
-.rstudio-themes-dark-menus [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab-selected div {
+body [id^="rstudio_label"][aria-selected="true"] div,
+body .dialogContent .gwt-TabLayoutPanelTab-selected div,
+body [id^="rstudio_label"][aria-selected="true"] div,
+body .dialogContent .gwt-TabLayoutPanelTab-selected div {
   background-color: transparent !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-light-menus .dialogContent button table,
-.rstudio-themes-light-menus .dialogContent button:not(:hover) table > tbody > tr > td > div,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-dark-menus .dialogContent button table,
-.rstudio-themes-dark-menus .dialogContent button:not(:hover) table > tbody > tr > td > div {
+body .dialogContent .gwt-Button-DialogAction table,
+body .dialogContent .gwt-Button-DialogAction table td,
+body .dialogContent button table,
+body .dialogContent button:not(:hover) table > tbody > tr > td > div,
+body .dialogContent .gwt-Button-DialogAction table,
+body .dialogContent .gwt-Button-DialogAction table td,
+body .dialogContent button table,
+body .dialogContent button:not(:hover) table > tbody > tr > td > div {
   background: #1e1e1e !important;
   color: #EEFFFF !important;
   border: none !important;
   box-shadow: none !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
+body .gwt-DialogBox .dialogContent [role="listbox"] > div,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [role="tablist"],
+body .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
+body .gwt-DialogBox .dialogContent [role="listbox"] > div,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [role="tablist"],
+body .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
   /* Dialog options lists and tabs */
   background: #1e1e1e !important;
   color: #EEFFFF !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
   background-color: #2b2b2b !important;
   border-color: #2b2b2b !important;
   color: #65737E !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #65737E !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
   color: #65737E !important;
 }
 
-.rstudio-themes-light-menus .dialogContent button,
-.rstudio-themes-dark-menus .dialogContent button {
+body .dialogContent button,
+body .dialogContent button {
   border-width: 2px !important;
   border-style: solid !important;
   border-color: #2b2b2b !important;
   border-radius: 3px !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-light-menus .dialogContent button:hover,
-.rstudio-themes-light-menus .dialogContent button:hover table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-light-menus .dialogContent button:hover table > tbody > tr > td > div,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-dark-menus .dialogContent button:hover,
-.rstudio-themes-dark-menus .dialogContent button:hover table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-dark-menus .dialogContent button:hover table > tbody > tr > td > div {
+body .dialogContent .gwt-Button-DialogAction:hover table,
+body .dialogContent .gwt-Button-DialogAction:hover table div,
+body .dialogContent button:hover,
+body .dialogContent button:hover table,
+body .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+body .dialogContent button:hover table > tbody > tr > td > div,
+body .dialogContent .gwt-Button-DialogAction:hover table,
+body .dialogContent .gwt-Button-DialogAction:hover table div,
+body .dialogContent button:hover,
+body .dialogContent button:hover table,
+body .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+body .dialogContent button:hover table > tbody > tr > td > div {
   color: #65737E !important;
   background: #383838 !important;
   border-color: #2b2b2b !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input,
-.rstudio-themes-dark-menus .dialogContent input {
+body .dialogContent input,
+body .dialogContent input {
   background: #1e1e1e !important;
   color: #FFCB6B !important;
   border-color: #2b2b2b !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input[type="checkbox"],
-.rstudio-themes-dark-menus .dialogContent input[type="checkbox"] {
+body .dialogContent input[type="checkbox"],
+body .dialogContent input[type="checkbox"] {
   background: #2b2b2b !important;
   color: #EEFFFF !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input[type="checkbox"]:checked::before,
-.rstudio-themes-dark-menus .dialogContent input[type="checkbox"]:checked::before {
+body .dialogContent input[type="checkbox"]:checked::before,
+body .dialogContent input[type="checkbox"]:checked::before {
   content: "\2713" !important;
   color: #EEFFFF !important;
   vertical-align: top;
@@ -2977,37 +2977,37 @@ input#rstudio_command_palette_search {
   font-weight: 600;
 }
 
-.rstudio-themes-light-menus .dialogContent select,
-.rstudio-themes-dark-menus .dialogContent select {
+body .dialogContent select,
+body .dialogContent select {
   background: #2b2b2b !important;
   color: #EEFFFF !important;
 }
 
-.rstudio-themes-light-menus .rstudio-HyperlinkLabel,
-.rstudio-themes-dark-menus .rstudio-HyperlinkLabel {
+body .rstudio-HyperlinkLabel,
+body .rstudio-HyperlinkLabel {
   color: #84FFFF;
 }
 
-.rstudio-themes-light-menus .search,
-.rstudio-themes-dark-menus .search {
+body .search,
+body .search {
   /* code search */
   background-color: #1e1e1e;
   color: #EEFFFF;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center img,
-.rstudio-themes-dark-menus .search .rstheme_center img {
+body .search .rstheme_center img,
+body .search .rstheme_center img {
   display: none;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center::before,
-.rstudio-themes-dark-menus .search .rstheme_center::before {
+body .search .rstheme_center::before,
+body .search .rstheme_center::before {
   content: '\27a0';
   color: #EEFFFF;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center > button::before,
-.rstudio-themes-dark-menus .search .rstheme_center > button::before {
+body .search .rstheme_center > button::before,
+body .search .rstheme_center > button::before {
   content: '\2297';
   color: #EEFFFF;
   position: relative;
@@ -3015,8 +3015,8 @@ input#rstudio_command_palette_search {
   font-size: 1.25em;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center > button:hover,
-.rstudio-themes-dark-menus .search .rstheme_center > button:hover {
+body .search .rstheme_center > button:hover,
+body .search .rstheme_center > button:hover {
   background: unset !important;
   border: unset !important;
 }

--- a/inst/themes/material-lighter.rstheme
+++ b/inst/themes/material-lighter.rstheme
@@ -17,35 +17,35 @@
   color: #272727;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #FAFAFA;
   color: #272727;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #FAFAFA;
   color: #272727;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #FAFAFA !important;
   color: #272727 !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table {
+body .ace_editor_theme table {
   background-color: #FAFAFA !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
+body .ace_editor_theme table thead > tr > th {
   background-color: #FAFAFA !important;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme a {
+body.ace_editor_theme a {
   color: #272727 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-light-menus .gwt-Label {
+body .gwt-Label {
   color: #272727;
 }
 
@@ -310,148 +310,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   background: #f0f0f0 !important;
   color: #272727 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
+body .rstudio-themes-default .rstudio-themes-background {
   background: #f0f0f0 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+body .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+body .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #f0f0f0;
   border-color: #FAFAFA;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
+body .rstudio-themes-default .rstudio-themes-border {
   border-color: #FAFAFA;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #FAFAFA !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #90A4AE;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-default .rstheme_center,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #FAFAFA !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #272727;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #FAFAFA !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #FAFAFA !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #B0BEC5 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
+body .search, body.rstudio-themes-default-menus .search {
   /* search */
   background: #FAFAFA !important;
 }
 
-.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #FF5370;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
+.rstheme_secondaryToolbar, body .dataGridHeader {
   background: #FAFAFA !important;
 }
 
 /* menu background */
-.rstudio-themes-light-menus .popupMiddleCenter,
-.rstudio-themes-light-menus .menuPopupMiddleCenter,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #E7EAEC !important;
   color: #272727 !important;
 }
 
-.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #272727 !important;
   background: #CFD8DC !important;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #FAFAFA;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #FAFAFA;
 }
 
-.rstudio-themes-light-menus .popupContent {
+body .popupContent {
   background: #E7EAEC;
   color: #272727;
   border-color: #FAFAFA;
 }
 
-.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #FAFAFA;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #E7EAEC;
   padding: 2px;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #272727;
   border: 0;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #E7EAEC;
 }
 
-.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #CFD8DC;
   color: #272727;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #FAFAFA !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #FAFAFA !important;
 }
 
@@ -473,36 +473,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-light-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
+body, body .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: whitesmoke rgba(250, 250, 250, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(250, 250, 250, 0.5);
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: whitesmoke;
   border-radius: 0px;
   border: 2px solid #FAFAFA;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #e8e8e8;
 }
 
@@ -517,26 +517,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-light-menus table.rstudio-themes-background td > div:first-child {
+body table.rstudio-themes-background td > div:first-child {
   border-color: #f0f0f0 !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
+body > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
   border-color: #f0f0f0;
 }
 
-.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   border-color: #f0f0f0;
 }
 
-.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel td {
+body > .rstudio-themes-default .gwt-SplitLayoutPanel td {
   border-color: #FAFAFA !important;
 }
 
 /* window containers */
-.rstudio-themes-light-menus
+body
 > .rstudio-themes-default
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -2730,275 +2730,275 @@ input#rstudio_command_palette_search {
   border-color: #FAFAFA;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #FAFAFA;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #FAFAFA;
   color: #272727;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #ededed;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #e1e1e1;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
   height: 40px !important;
   background: #FAFAFA;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
   padding-left: 20px;
   padding-right: 20px;
   height: 40px;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
   vertical-align: middle !important;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
   height: 40px !important;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
+body .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
+body .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
   border-color: #FAFAFA !important;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
   display: none;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   display: inline-block;
   position: absolute !important;
   top: 0 !important;
   padding-left: 3px;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   padding-top: 5px;
 }
 
-.rstudio-themes-light-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-light-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
-.rstudio-themes-dark-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
+body .windowframe .gwt-TabLayoutPanel > div:last-child,
+body .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
+body .windowframe .gwt-TabLayoutPanel > div:last-child,
+body .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
   top: 38px !important;
 }
 
-.rstudio-themes-light-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
-.rstudio-themes-dark-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
+body .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
+body .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
   height: 40px !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_dialog"],
-.rstudio-themes-light-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-light-menus .dialogTopCenter,
-.rstudio-themes-light-menus .dialogTop,
-.rstudio-themes-light-menus .dialogMiddle,
-.rstudio-themes-light-menus .dataGridHeader,
-.rstudio-themes-dark-menus [id^="rstudio_dialog"],
-.rstudio-themes-dark-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-dark-menus .dialogTopCenter,
-.rstudio-themes-dark-menus .dialogTop,
-.rstudio-themes-dark-menus .dialogMiddle,
-.rstudio-themes-dark-menus .dataGridHeader {
+body [id^="rstudio_dialog"],
+body :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+body .dialogTopCenter,
+body .dialogTop,
+body .dialogMiddle,
+body .dataGridHeader,
+body [id^="rstudio_dialog"],
+body :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+body .dialogTopCenter,
+body .dialogTop,
+body .dialogMiddle,
+body .dataGridHeader {
   background: #f0f0f0 !important;
   color: #272727 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
-.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table,
-.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
+body .dialogContent > table:first-child:last-child :not(button) > table, body .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
+body .dialogContent > table:first-child:last-child :not(button) > table,
+body .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
   background: #f0f0f0 !important;
   color: #272727 !important;
   border-color: #f0f0f0 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent label.gwt-Label,
-.rstudio-themes-light-menus .dialogContent .gwt-RadioButton ~ *,
-.rstudio-themes-dark-menus .dialogContent label.gwt-Label,
-.rstudio-themes-dark-menus .dialogContent .gwt-RadioButton ~ * {
+body .dialogContent label.gwt-Label,
+body .dialogContent .gwt-RadioButton ~ *,
+body .dialogContent label.gwt-Label,
+body .dialogContent .gwt-RadioButton ~ * {
   color: #7E939E !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
+body .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
+body .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
   color: #80CBC4 !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_dialog"],
-.rstudio-themes-light-menus .dialogTop .dialogTopCenter,
-.rstudio-themes-light-menus .gwt-DialogBox-ModalDialog,
-.rstudio-themes-light-menus .dataGridHeader,
-.rstudio-themes-dark-menus [id^="rstudio_dialog"],
-.rstudio-themes-dark-menus .dialogTop .dialogTopCenter,
-.rstudio-themes-dark-menus .gwt-DialogBox-ModalDialog,
-.rstudio-themes-dark-menus .dataGridHeader {
+body [id^="rstudio_dialog"],
+body .dialogTop .dialogTopCenter,
+body .gwt-DialogBox-ModalDialog,
+body .dataGridHeader,
+body [id^="rstudio_dialog"],
+body .dialogTop .dialogTopCenter,
+body .gwt-DialogBox-ModalDialog,
+body .dataGridHeader {
   /* outer border */
   border-color: #e3e3e3 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent > table div,
-.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
-.rstudio-themes-dark-menus .dialogContent > table div,
-.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
+body .dialogContent > table div,
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
+body .dialogContent > table div,
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
   border-color: #e3e3e3;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab,
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab {
+body .dialogContent .gwt-TabLayoutPanelTab,
+body .dialogContent .gwt-TabLayoutPanelTab {
   border-color: #e3e3e3 !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab-selected div,
-.rstudio-themes-dark-menus [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab-selected div {
+body [id^="rstudio_label"][aria-selected="true"] div,
+body .dialogContent .gwt-TabLayoutPanelTab-selected div,
+body [id^="rstudio_label"][aria-selected="true"] div,
+body .dialogContent .gwt-TabLayoutPanelTab-selected div {
   background-color: transparent !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-light-menus .dialogContent button table,
-.rstudio-themes-light-menus .dialogContent button:not(:hover) table > tbody > tr > td > div,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-dark-menus .dialogContent button table,
-.rstudio-themes-dark-menus .dialogContent button:not(:hover) table > tbody > tr > td > div {
+body .dialogContent .gwt-Button-DialogAction table,
+body .dialogContent .gwt-Button-DialogAction table td,
+body .dialogContent button table,
+body .dialogContent button:not(:hover) table > tbody > tr > td > div,
+body .dialogContent .gwt-Button-DialogAction table,
+body .dialogContent .gwt-Button-DialogAction table td,
+body .dialogContent button table,
+body .dialogContent button:not(:hover) table > tbody > tr > td > div {
   background: #f0f0f0 !important;
   color: #272727 !important;
   border: none !important;
   box-shadow: none !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
+body .gwt-DialogBox .dialogContent [role="listbox"] > div,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [role="tablist"],
+body .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
+body .gwt-DialogBox .dialogContent [role="listbox"] > div,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [role="tablist"],
+body .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
   /* Dialog options lists and tabs */
   background: #f0f0f0 !important;
   color: #272727 !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
   background-color: #e3e3e3 !important;
   border-color: #e3e3e3 !important;
   color: #7E939E !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #7E939E !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
   color: #7E939E !important;
 }
 
-.rstudio-themes-light-menus .dialogContent button,
-.rstudio-themes-dark-menus .dialogContent button {
+body .dialogContent button,
+body .dialogContent button {
   border-width: 2px !important;
   border-style: solid !important;
   border-color: #e3e3e3 !important;
   border-radius: 3px !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-light-menus .dialogContent button:hover,
-.rstudio-themes-light-menus .dialogContent button:hover table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-light-menus .dialogContent button:hover table > tbody > tr > td > div,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-dark-menus .dialogContent button:hover,
-.rstudio-themes-dark-menus .dialogContent button:hover table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-dark-menus .dialogContent button:hover table > tbody > tr > td > div {
+body .dialogContent .gwt-Button-DialogAction:hover table,
+body .dialogContent .gwt-Button-DialogAction:hover table div,
+body .dialogContent button:hover,
+body .dialogContent button:hover table,
+body .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+body .dialogContent button:hover table > tbody > tr > td > div,
+body .dialogContent .gwt-Button-DialogAction:hover table,
+body .dialogContent .gwt-Button-DialogAction:hover table div,
+body .dialogContent button:hover,
+body .dialogContent button:hover table,
+body .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+body .dialogContent button:hover table > tbody > tr > td > div {
   color: #7E939E !important;
   background: white !important;
   border-color: #e3e3e3 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input,
-.rstudio-themes-dark-menus .dialogContent input {
+body .dialogContent input,
+body .dialogContent input {
   background: #f0f0f0 !important;
   color: #FFB62C !important;
   border-color: #e3e3e3 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input[type="checkbox"],
-.rstudio-themes-dark-menus .dialogContent input[type="checkbox"] {
+body .dialogContent input[type="checkbox"],
+body .dialogContent input[type="checkbox"] {
   background: #fdfdfd !important;
   color: #272727 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input[type="checkbox"]:checked::before,
-.rstudio-themes-dark-menus .dialogContent input[type="checkbox"]:checked::before {
+body .dialogContent input[type="checkbox"]:checked::before,
+body .dialogContent input[type="checkbox"]:checked::before {
   content: "\2713" !important;
   color: #272727 !important;
   vertical-align: top;
@@ -3006,37 +3006,37 @@ input#rstudio_command_palette_search {
   font-weight: 600;
 }
 
-.rstudio-themes-light-menus .dialogContent select,
-.rstudio-themes-dark-menus .dialogContent select {
+body .dialogContent select,
+body .dialogContent select {
   background: #fdfdfd !important;
   color: #272727 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-HyperlinkLabel,
-.rstudio-themes-dark-menus .rstudio-HyperlinkLabel {
+body .rstudio-HyperlinkLabel,
+body .rstudio-HyperlinkLabel {
   color: #80CBC4;
 }
 
-.rstudio-themes-light-menus .search,
-.rstudio-themes-dark-menus .search {
+body .search,
+body .search {
   /* code search */
   background-color: #f0f0f0;
   color: #272727;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center img,
-.rstudio-themes-dark-menus .search .rstheme_center img {
+body .search .rstheme_center img,
+body .search .rstheme_center img {
   display: none;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center::before,
-.rstudio-themes-dark-menus .search .rstheme_center::before {
+body .search .rstheme_center::before,
+body .search .rstheme_center::before {
   content: '\27a0';
   color: #272727;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center > button::before,
-.rstudio-themes-dark-menus .search .rstheme_center > button::before {
+body .search .rstheme_center > button::before,
+body .search .rstheme_center > button::before {
   content: '\2297';
   color: #272727;
   position: relative;
@@ -3044,8 +3044,8 @@ input#rstudio_command_palette_search {
   font-size: 1.25em;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center > button:hover,
-.rstudio-themes-dark-menus .search .rstheme_center > button:hover {
+body .search .rstheme_center > button:hover,
+body .search .rstheme_center > button:hover {
   background: unset !important;
   border: unset !important;
 }

--- a/inst/themes/material-lighter.rstheme
+++ b/inst/themes/material-lighter.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: Material Lighter {rsthemes} */
 /* rs-theme-is-dark: FALSE */
@@ -17,35 +17,35 @@
   color: #272727;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-light-menus.ace_editor_theme {
   background-color: #FAFAFA;
   color: #272727;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #FAFAFA;
   color: #272727;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-light-menus .ace_editor_theme {
   background-color: #FAFAFA !important;
   color: #272727 !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table {
+.rstudio-themes-light-menus .ace_editor_theme table {
   background-color: #FAFAFA !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table thead > tr > th {
+.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
   background-color: #FAFAFA !important;
 }
 
-.rstudio-themes-flat.ace_editor_theme a {
+.rstudio-themes-light-menus.ace_editor_theme a {
   color: #272727 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-light-menus .gwt-Label {
   color: #272727;
 }
 
@@ -310,148 +310,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   background: #f0f0f0 !important;
   color: #272727 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
   background: #f0f0f0 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #f0f0f0;
   border-color: #FAFAFA;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
   border-color: #FAFAFA;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #FAFAFA !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #90A4AE;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-default .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #FAFAFA !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #272727;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #FAFAFA !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper {
   background: #FAFAFA !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
   color: #B0BEC5 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .search, .rstudio-themes-flat.rstudio-themes-default-menus .search {
+.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
   /* search */
   background: #FAFAFA !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #FF5370;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
   background: #FAFAFA !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-light-menus .popupMiddleCenter,
+.rstudio-themes-light-menus .menuPopupMiddleCenter,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter {
   background: #E7EAEC !important;
   color: #272727 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #272727 !important;
   background: #CFD8DC !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-light-menus .themedPopupPanel {
   border: solid 1px #FAFAFA;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #FAFAFA;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-light-menus .popupContent {
   background: #E7EAEC;
   color: #272727;
   border-color: #FAFAFA;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #FAFAFA;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
   background: #E7EAEC;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
   background: #272727;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #E7EAEC;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #CFD8DC;
   color: #272727;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #FAFAFA !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #FAFAFA !important;
 }
 
@@ -473,36 +473,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-light-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: whitesmoke rgba(250, 250, 250, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(250, 250, 250, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: whitesmoke;
   border-radius: 0px;
   border: 2px solid #FAFAFA;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #e8e8e8;
 }
 
@@ -517,26 +517,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-flat table.rstudio-themes-background td > div:first-child {
+.rstudio-themes-light-menus table.rstudio-themes-background td > div:first-child {
   border-color: #f0f0f0 !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-flat > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
+.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
   border-color: #f0f0f0;
 }
 
-.rstudio-themes-flat > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   border-color: #f0f0f0;
 }
 
-.rstudio-themes-flat > .rstudio-themes-default .gwt-SplitLayoutPanel td {
+.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel td {
   border-color: #FAFAFA !important;
 }
 
 /* window containers */
-.rstudio-themes-flat
+.rstudio-themes-light-menus
 > .rstudio-themes-default
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -584,15 +584,16 @@ table.rstheme_tabLayoutCenter .gwt-Label,
   border: none;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTab-selected {
+  /* remove border from panes */
+}
+
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
   box-shadow: 0 -2px 0 #80CBC4 inset;
   border-radius: 0 !important;
 }
 
-/* remove border from panes */
-.rstudio-themes-flat
-:-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
-> div:last-child {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTab-selected .rstudio-themes-light-menus :-webkit-any(.windowframe, .rstheme_minimizedWindowObject) > div:last-child {
   border-color: #f0f0f0 !important;
 }
 
@@ -2729,202 +2730,275 @@ input#rstudio_command_palette_search {
   border-color: #FAFAFA;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #FAFAFA;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #FAFAFA;
   color: #272727;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #ededed;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #e1e1e1;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
   height: 40px !important;
   background: #FAFAFA;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
   padding-left: 20px;
   padding-right: 20px;
   height: 40px;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
   vertical-align: middle !important;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
   height: 40px !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
+.rstudio-themes-light-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
   border-color: #FAFAFA !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
   display: none;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   display: inline-block;
   position: absolute !important;
   top: 0 !important;
   padding-left: 3px;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   padding-top: 5px;
 }
 
-.rstudio-themes-flat .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-flat .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
+.rstudio-themes-light-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
+.rstudio-themes-light-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
+.rstudio-themes-dark-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
   top: 38px !important;
 }
 
-.windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
+.rstudio-themes-light-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
+.rstudio-themes-dark-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
   height: 40px !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_dialog"],
-.rstudio-themes-flat :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-flat .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-flat .dialogTopCenter,
-.rstudio-themes-flat .dialogTop,
-.rstudio-themes-flat .dialogMiddle,
-.rstudio-themes-flat .dataGridHeader {
+.rstudio-themes-light-menus [id^="rstudio_dialog"],
+.rstudio-themes-light-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+.rstudio-themes-light-menus .dialogTopCenter,
+.rstudio-themes-light-menus .dialogTop,
+.rstudio-themes-light-menus .dialogMiddle,
+.rstudio-themes-light-menus .dataGridHeader,
+.rstudio-themes-dark-menus [id^="rstudio_dialog"],
+.rstudio-themes-dark-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+.rstudio-themes-dark-menus .dialogTopCenter,
+.rstudio-themes-dark-menus .dialogTop,
+.rstudio-themes-dark-menus .dialogMiddle,
+.rstudio-themes-dark-menus .dataGridHeader {
   background: #f0f0f0 !important;
   color: #272727 !important;
 }
 
-.rstudio-themes-flat .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-flat .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
+.rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
+.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table,
+.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
   background: #f0f0f0 !important;
   color: #272727 !important;
   border-color: #f0f0f0 !important;
 }
 
-.rstudio-themes-flat .dialogContent label.gwt-Label,
-.rstudio-themes-flat .dialogContent .gwt-RadioButton ~ * {
+.rstudio-themes-light-menus .dialogContent label.gwt-Label,
+.rstudio-themes-light-menus .dialogContent .gwt-RadioButton ~ *,
+.rstudio-themes-dark-menus .dialogContent label.gwt-Label,
+.rstudio-themes-dark-menus .dialogContent .gwt-RadioButton ~ * {
   color: #7E939E !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
   color: #80CBC4 !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_dialog"],
-.rstudio-themes-flat .dialogTop .dialogTopCenter,
-.rstudio-themes-flat .gwt-DialogBox-ModalDialog,
-.rstudio-themes-flat .dataGridHeader {
+.rstudio-themes-light-menus [id^="rstudio_dialog"],
+.rstudio-themes-light-menus .dialogTop .dialogTopCenter,
+.rstudio-themes-light-menus .gwt-DialogBox-ModalDialog,
+.rstudio-themes-light-menus .dataGridHeader,
+.rstudio-themes-dark-menus [id^="rstudio_dialog"],
+.rstudio-themes-dark-menus .dialogTop .dialogTopCenter,
+.rstudio-themes-dark-menus .gwt-DialogBox-ModalDialog,
+.rstudio-themes-dark-menus .dataGridHeader {
   /* outer border */
   border-color: #e3e3e3 !important;
 }
 
-.rstudio-themes-flat .dialogContent > table div,
-.rstudio-themes-flat .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
+.rstudio-themes-light-menus .dialogContent > table div,
+.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
+.rstudio-themes-dark-menus .dialogContent > table div,
+.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
   border-color: #e3e3e3;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelTab {
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab,
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab {
   border-color: #e3e3e3 !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelTab-selected div {
+.rstudio-themes-light-menus [id^="rstudio_label"][aria-selected="true"] div,
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab-selected div,
+.rstudio-themes-dark-menus [id^="rstudio_label"][aria-selected="true"] div,
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab-selected div {
   background-color: transparent !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-flat .dialogContent button table,
-.rstudio-themes-flat .dialogContent button:not(:hover) table > tbody > tr > td > div {
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table td,
+.rstudio-themes-light-menus .dialogContent button table,
+.rstudio-themes-light-menus .dialogContent button:not(:hover) table > tbody > tr > td > div,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table td,
+.rstudio-themes-dark-menus .dialogContent button table,
+.rstudio-themes-dark-menus .dialogContent button:not(:hover) table > tbody > tr > td > div {
   background: #f0f0f0 !important;
   color: #272727 !important;
   border: none !important;
   box-shadow: none !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
   /* Dialog options lists and tabs */
   background: #f0f0f0 !important;
   color: #272727 !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
   background-color: #e3e3e3 !important;
   border-color: #e3e3e3 !important;
   color: #7E939E !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #7E939E !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
   color: #7E939E !important;
 }
 
-.rstudio-themes-flat .dialogContent button {
+.rstudio-themes-light-menus .dialogContent button,
+.rstudio-themes-dark-menus .dialogContent button {
   border-width: 2px !important;
   border-style: solid !important;
   border-color: #e3e3e3 !important;
   border-radius: 3px !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-flat .dialogContent button:hover,
-.rstudio-themes-flat .dialogContent button:hover table,
-.rstudio-themes-flat .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-flat .dialogContent button:hover table > tbody > tr > td > div {
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table div,
+.rstudio-themes-light-menus .dialogContent button:hover,
+.rstudio-themes-light-menus .dialogContent button:hover table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+.rstudio-themes-light-menus .dialogContent button:hover table > tbody > tr > td > div,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table div,
+.rstudio-themes-dark-menus .dialogContent button:hover,
+.rstudio-themes-dark-menus .dialogContent button:hover table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+.rstudio-themes-dark-menus .dialogContent button:hover table > tbody > tr > td > div {
   color: #7E939E !important;
   background: white !important;
   border-color: #e3e3e3 !important;
 }
 
-.rstudio-themes-flat .dialogContent input {
+.rstudio-themes-light-menus .dialogContent input,
+.rstudio-themes-dark-menus .dialogContent input {
   background: #f0f0f0 !important;
   color: #FFB62C !important;
   border-color: #e3e3e3 !important;
 }
 
-.rstudio-themes-flat .dialogContent input[type="checkbox"] {
+.rstudio-themes-light-menus .dialogContent input[type="checkbox"],
+.rstudio-themes-dark-menus .dialogContent input[type="checkbox"] {
   background: #fdfdfd !important;
   color: #272727 !important;
 }
 
-.rstudio-themes-flat .dialogContent input[type="checkbox"]:checked::before {
+.rstudio-themes-light-menus .dialogContent input[type="checkbox"]:checked::before,
+.rstudio-themes-dark-menus .dialogContent input[type="checkbox"]:checked::before {
   content: "\2713" !important;
   color: #272727 !important;
   vertical-align: top;
@@ -2932,31 +3006,37 @@ input#rstudio_command_palette_search {
   font-weight: 600;
 }
 
-.rstudio-themes-flat .dialogContent select {
+.rstudio-themes-light-menus .dialogContent select,
+.rstudio-themes-dark-menus .dialogContent select {
   background: #fdfdfd !important;
   color: #272727 !important;
 }
 
-.rstudio-themes-flat .rstudio-HyperlinkLabel {
+.rstudio-themes-light-menus .rstudio-HyperlinkLabel,
+.rstudio-themes-dark-menus .rstudio-HyperlinkLabel {
   color: #80CBC4;
 }
 
-.rstudio-themes-flat .search {
+.rstudio-themes-light-menus .search,
+.rstudio-themes-dark-menus .search {
   /* code search */
   background-color: #f0f0f0;
   color: #272727;
 }
 
-.rstudio-themes-flat .search .rstheme_center img {
+.rstudio-themes-light-menus .search .rstheme_center img,
+.rstudio-themes-dark-menus .search .rstheme_center img {
   display: none;
 }
 
-.rstudio-themes-flat .search .rstheme_center::before {
+.rstudio-themes-light-menus .search .rstheme_center::before,
+.rstudio-themes-dark-menus .search .rstheme_center::before {
   content: '\27a0';
   color: #272727;
 }
 
-.rstudio-themes-flat .search .rstheme_center > button::before {
+.rstudio-themes-light-menus .search .rstheme_center > button::before,
+.rstudio-themes-dark-menus .search .rstheme_center > button::before {
   content: '\2297';
   color: #272727;
   position: relative;
@@ -2964,7 +3044,8 @@ input#rstudio_command_palette_search {
   font-size: 1.25em;
 }
 
-.rstudio-themes-flat .search .rstheme_center > button:hover {
+.rstudio-themes-light-menus .search .rstheme_center > button:hover,
+.rstudio-themes-dark-menus .search .rstheme_center > button:hover {
   background: unset !important;
   border: unset !important;
 }

--- a/inst/themes/material-ocean.rstheme
+++ b/inst/themes/material-ocean.rstheme
@@ -17,26 +17,26 @@
   color: #8F93A2;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #0F111A;
   color: #8F93A2;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #0F111A;
   color: #8F93A2;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #0F111A;
   color: #8F93A2;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #8F93A2;
 }
 
@@ -293,112 +293,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #0F111A !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #4B526D;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #0F111A !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #0F111A !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #0F111A !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #464B5D !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #0F111A !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #84FFFF;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #0F111A !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #1A1C25 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #ffffff !important;
   background: #3B3F51 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #0F111A;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #0F111A;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #1A1C25;
   color: #ffffff;
   border-color: #0F111A;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #0F111A;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #1A1C25;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #ffffff;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1A1C25;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #3B3F51;
   color: #ffffff;
 }
@@ -412,15 +412,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #0F111A !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #0F111A !important;
 }
 
@@ -442,37 +442,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #0b0d14 rgba(15, 17, 26, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(15, 17, 26, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #0b0d14;
   border-radius: 0px;
   border: 2px solid #0F111A;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #151724;
 }
 
@@ -487,26 +487,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-dark-menus .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
+body .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
   border-color: #151724 !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
   border-color: #151724;
 }
 
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
   border-color: #151724;
 }
 
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
   border-color: #0F111A !important;
 }
 
 /* window containers */
-.rstudio-themes-dark-menus
+body
 > .rstudio-themes-dark
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -2701,275 +2701,275 @@ input#rstudio_command_palette_search {
   border-color: #0F111A;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #0F111A;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #0F111A;
   color: #8F93A2;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #181c2a;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #22263a;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
   height: 40px !important;
   background: #0F111A;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
   padding-left: 20px;
   padding-right: 20px;
   height: 40px;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
   vertical-align: middle !important;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
   height: 40px !important;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
+body .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
+body .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
   border-color: #0F111A !important;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
   display: none;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   display: inline-block;
   position: absolute !important;
   top: 0 !important;
   padding-left: 3px;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   padding-top: 5px;
 }
 
-.rstudio-themes-light-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-light-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
-.rstudio-themes-dark-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
+body .windowframe .gwt-TabLayoutPanel > div:last-child,
+body .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
+body .windowframe .gwt-TabLayoutPanel > div:last-child,
+body .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
   top: 38px !important;
 }
 
-.rstudio-themes-light-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
-.rstudio-themes-dark-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
+body .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
+body .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
   height: 40px !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_dialog"],
-.rstudio-themes-light-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-light-menus .dialogTopCenter,
-.rstudio-themes-light-menus .dialogTop,
-.rstudio-themes-light-menus .dialogMiddle,
-.rstudio-themes-light-menus .dataGridHeader,
-.rstudio-themes-dark-menus [id^="rstudio_dialog"],
-.rstudio-themes-dark-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-dark-menus .dialogTopCenter,
-.rstudio-themes-dark-menus .dialogTop,
-.rstudio-themes-dark-menus .dialogMiddle,
-.rstudio-themes-dark-menus .dataGridHeader {
+body [id^="rstudio_dialog"],
+body :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+body .dialogTopCenter,
+body .dialogTop,
+body .dialogMiddle,
+body .dataGridHeader,
+body [id^="rstudio_dialog"],
+body :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+body .dialogTopCenter,
+body .dialogTop,
+body .dialogMiddle,
+body .dataGridHeader {
   background: #151724 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
-.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table,
-.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
+body .dialogContent > table:first-child:last-child :not(button) > table, body .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
+body .dialogContent > table:first-child:last-child :not(button) > table,
+body .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
   background: #151724 !important;
   color: #ffffff !important;
   border-color: #151724 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent label.gwt-Label,
-.rstudio-themes-light-menus .dialogContent .gwt-RadioButton ~ *,
-.rstudio-themes-dark-menus .dialogContent label.gwt-Label,
-.rstudio-themes-dark-menus .dialogContent .gwt-RadioButton ~ * {
+body .dialogContent label.gwt-Label,
+body .dialogContent .gwt-RadioButton ~ *,
+body .dialogContent label.gwt-Label,
+body .dialogContent .gwt-RadioButton ~ * {
   color: #8F93A2 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
+body .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
+body .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
   color: #84FFFF !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_dialog"],
-.rstudio-themes-light-menus .dialogTop .dialogTopCenter,
-.rstudio-themes-light-menus .gwt-DialogBox-ModalDialog,
-.rstudio-themes-light-menus .dataGridHeader,
-.rstudio-themes-dark-menus [id^="rstudio_dialog"],
-.rstudio-themes-dark-menus .dialogTop .dialogTopCenter,
-.rstudio-themes-dark-menus .gwt-DialogBox-ModalDialog,
-.rstudio-themes-dark-menus .dataGridHeader {
+body [id^="rstudio_dialog"],
+body .dialogTop .dialogTopCenter,
+body .gwt-DialogBox-ModalDialog,
+body .dataGridHeader,
+body [id^="rstudio_dialog"],
+body .dialogTop .dialogTopCenter,
+body .gwt-DialogBox-ModalDialog,
+body .dataGridHeader {
   /* outer border */
   border-color: #1e2234 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent > table div,
-.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
-.rstudio-themes-dark-menus .dialogContent > table div,
-.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
+body .dialogContent > table div,
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
+body .dialogContent > table div,
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
   border-color: #1e2234;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab,
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab {
+body .dialogContent .gwt-TabLayoutPanelTab,
+body .dialogContent .gwt-TabLayoutPanelTab {
   border-color: #1e2234 !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab-selected div,
-.rstudio-themes-dark-menus [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab-selected div {
+body [id^="rstudio_label"][aria-selected="true"] div,
+body .dialogContent .gwt-TabLayoutPanelTab-selected div,
+body [id^="rstudio_label"][aria-selected="true"] div,
+body .dialogContent .gwt-TabLayoutPanelTab-selected div {
   background-color: transparent !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-light-menus .dialogContent button table,
-.rstudio-themes-light-menus .dialogContent button:not(:hover) table > tbody > tr > td > div,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-dark-menus .dialogContent button table,
-.rstudio-themes-dark-menus .dialogContent button:not(:hover) table > tbody > tr > td > div {
+body .dialogContent .gwt-Button-DialogAction table,
+body .dialogContent .gwt-Button-DialogAction table td,
+body .dialogContent button table,
+body .dialogContent button:not(:hover) table > tbody > tr > td > div,
+body .dialogContent .gwt-Button-DialogAction table,
+body .dialogContent .gwt-Button-DialogAction table td,
+body .dialogContent button table,
+body .dialogContent button:not(:hover) table > tbody > tr > td > div {
   background: #151724 !important;
   color: #ffffff !important;
   border: none !important;
   box-shadow: none !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
+body .gwt-DialogBox .dialogContent [role="listbox"] > div,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [role="tablist"],
+body .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
+body .gwt-DialogBox .dialogContent [role="listbox"] > div,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [role="tablist"],
+body .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
   /* Dialog options lists and tabs */
   background: #151724 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
   background-color: #1e2234 !important;
   border-color: #1e2234 !important;
   color: #8F93A2 !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #8F93A2 !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
   color: #8F93A2 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent button,
-.rstudio-themes-dark-menus .dialogContent button {
+body .dialogContent button,
+body .dialogContent button {
   border-width: 2px !important;
   border-style: solid !important;
   border-color: #1e2234 !important;
   border-radius: 3px !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-light-menus .dialogContent button:hover,
-.rstudio-themes-light-menus .dialogContent button:hover table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-light-menus .dialogContent button:hover table > tbody > tr > td > div,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-dark-menus .dialogContent button:hover,
-.rstudio-themes-dark-menus .dialogContent button:hover table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-dark-menus .dialogContent button:hover table > tbody > tr > td > div {
+body .dialogContent .gwt-Button-DialogAction:hover table,
+body .dialogContent .gwt-Button-DialogAction:hover table div,
+body .dialogContent button:hover,
+body .dialogContent button:hover table,
+body .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+body .dialogContent button:hover table > tbody > tr > td > div,
+body .dialogContent .gwt-Button-DialogAction:hover table,
+body .dialogContent .gwt-Button-DialogAction:hover table div,
+body .dialogContent button:hover,
+body .dialogContent button:hover table,
+body .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+body .dialogContent button:hover table > tbody > tr > td > div {
   color: #8F93A2 !important;
   background: #272c44 !important;
   border-color: #1e2234 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input,
-.rstudio-themes-dark-menus .dialogContent input {
+body .dialogContent input,
+body .dialogContent input {
   background: #151724 !important;
   color: #FFCB6B !important;
   border-color: #1e2234 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input[type="checkbox"],
-.rstudio-themes-dark-menus .dialogContent input[type="checkbox"] {
+body .dialogContent input[type="checkbox"],
+body .dialogContent input[type="checkbox"] {
   background: #1e2234 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input[type="checkbox"]:checked::before,
-.rstudio-themes-dark-menus .dialogContent input[type="checkbox"]:checked::before {
+body .dialogContent input[type="checkbox"]:checked::before,
+body .dialogContent input[type="checkbox"]:checked::before {
   content: "\2713" !important;
   color: #ffffff !important;
   vertical-align: top;
@@ -2977,37 +2977,37 @@ input#rstudio_command_palette_search {
   font-weight: 600;
 }
 
-.rstudio-themes-light-menus .dialogContent select,
-.rstudio-themes-dark-menus .dialogContent select {
+body .dialogContent select,
+body .dialogContent select {
   background: #1e2234 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-light-menus .rstudio-HyperlinkLabel,
-.rstudio-themes-dark-menus .rstudio-HyperlinkLabel {
+body .rstudio-HyperlinkLabel,
+body .rstudio-HyperlinkLabel {
   color: #84FFFF;
 }
 
-.rstudio-themes-light-menus .search,
-.rstudio-themes-dark-menus .search {
+body .search,
+body .search {
   /* code search */
   background-color: #151724;
   color: #ffffff;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center img,
-.rstudio-themes-dark-menus .search .rstheme_center img {
+body .search .rstheme_center img,
+body .search .rstheme_center img {
   display: none;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center::before,
-.rstudio-themes-dark-menus .search .rstheme_center::before {
+body .search .rstheme_center::before,
+body .search .rstheme_center::before {
   content: '\27a0';
   color: #ffffff;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center > button::before,
-.rstudio-themes-dark-menus .search .rstheme_center > button::before {
+body .search .rstheme_center > button::before,
+body .search .rstheme_center > button::before {
   content: '\2297';
   color: #ffffff;
   position: relative;
@@ -3015,8 +3015,8 @@ input#rstudio_command_palette_search {
   font-size: 1.25em;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center > button:hover,
-.rstudio-themes-dark-menus .search .rstheme_center > button:hover {
+body .search .rstheme_center > button:hover,
+body .search .rstheme_center > button:hover {
   background: unset !important;
   border: unset !important;
 }

--- a/inst/themes/material-ocean.rstheme
+++ b/inst/themes/material-ocean.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: Material Ocean {rsthemes} */
 /* rs-theme-is-dark: TRUE */
@@ -17,26 +17,26 @@
   color: #8F93A2;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #0F111A;
   color: #8F93A2;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #0F111A;
   color: #8F93A2;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #0F111A;
   color: #8F93A2;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #8F93A2;
 }
 
@@ -271,134 +271,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #151724 !important;
   color: #ffffff !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #151724 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #151724;
   border-color: #0F111A;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #0F111A;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #0F111A !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #4B526D;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #0F111A !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ffffff;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #0F111A !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #0F111A !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #464B5D !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #0F111A !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #84FFFF;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #0F111A !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #1A1C25 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #ffffff !important;
   background: #3B3F51 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #0F111A;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #0F111A;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #1A1C25;
   color: #ffffff;
   border-color: #0F111A;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #0F111A;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #1A1C25;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #ffffff;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1A1C25;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #3B3F51;
   color: #ffffff;
 }
@@ -412,15 +412,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #0F111A !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #0F111A !important;
 }
 
@@ -442,37 +442,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #0b0d14 rgba(15, 17, 26, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(15, 17, 26, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #0b0d14;
   border-radius: 0px;
   border: 2px solid #0F111A;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #151724;
 }
 
@@ -487,26 +487,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-flat .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
+.rstudio-themes-dark-menus .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
   border-color: #151724 !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
   border-color: #151724;
 }
 
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
   border-color: #151724;
 }
 
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
   border-color: #0F111A !important;
 }
 
 /* window containers */
-.rstudio-themes-flat
+.rstudio-themes-dark-menus
 > .rstudio-themes-dark
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -555,15 +555,16 @@ table.rstheme_tabLayoutCenter .gwt-Label,
   border: none;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected {
+  /* remove border from panes */
+}
+
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
   box-shadow: 0 -2px 0 #84FFFF inset;
   border-radius: 0 !important;
 }
 
-/* remove border from panes */
-.rstudio-themes-flat
-:-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
-> div:last-child {
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected .rstudio-themes-dark-menus :-webkit-any(.windowframe, .rstheme_minimizedWindowObject) > div:last-child {
   border-color: #151724 !important;
 }
 
@@ -2700,202 +2701,275 @@ input#rstudio_command_palette_search {
   border-color: #0F111A;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #0F111A;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #0F111A;
   color: #8F93A2;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #181c2a;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #22263a;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
   height: 40px !important;
   background: #0F111A;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
   padding-left: 20px;
   padding-right: 20px;
   height: 40px;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
   vertical-align: middle !important;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
   height: 40px !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
+.rstudio-themes-light-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
   border-color: #0F111A !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
   display: none;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   display: inline-block;
   position: absolute !important;
   top: 0 !important;
   padding-left: 3px;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   padding-top: 5px;
 }
 
-.rstudio-themes-flat .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-flat .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
+.rstudio-themes-light-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
+.rstudio-themes-light-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
+.rstudio-themes-dark-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
   top: 38px !important;
 }
 
-.windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
+.rstudio-themes-light-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
+.rstudio-themes-dark-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
   height: 40px !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_dialog"],
-.rstudio-themes-flat :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-flat .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-flat .dialogTopCenter,
-.rstudio-themes-flat .dialogTop,
-.rstudio-themes-flat .dialogMiddle,
-.rstudio-themes-flat .dataGridHeader {
+.rstudio-themes-light-menus [id^="rstudio_dialog"],
+.rstudio-themes-light-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+.rstudio-themes-light-menus .dialogTopCenter,
+.rstudio-themes-light-menus .dialogTop,
+.rstudio-themes-light-menus .dialogMiddle,
+.rstudio-themes-light-menus .dataGridHeader,
+.rstudio-themes-dark-menus [id^="rstudio_dialog"],
+.rstudio-themes-dark-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+.rstudio-themes-dark-menus .dialogTopCenter,
+.rstudio-themes-dark-menus .dialogTop,
+.rstudio-themes-dark-menus .dialogMiddle,
+.rstudio-themes-dark-menus .dataGridHeader {
   background: #151724 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-flat .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
+.rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
+.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table,
+.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
   background: #151724 !important;
   color: #ffffff !important;
   border-color: #151724 !important;
 }
 
-.rstudio-themes-flat .dialogContent label.gwt-Label,
-.rstudio-themes-flat .dialogContent .gwt-RadioButton ~ * {
+.rstudio-themes-light-menus .dialogContent label.gwt-Label,
+.rstudio-themes-light-menus .dialogContent .gwt-RadioButton ~ *,
+.rstudio-themes-dark-menus .dialogContent label.gwt-Label,
+.rstudio-themes-dark-menus .dialogContent .gwt-RadioButton ~ * {
   color: #8F93A2 !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
   color: #84FFFF !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_dialog"],
-.rstudio-themes-flat .dialogTop .dialogTopCenter,
-.rstudio-themes-flat .gwt-DialogBox-ModalDialog,
-.rstudio-themes-flat .dataGridHeader {
+.rstudio-themes-light-menus [id^="rstudio_dialog"],
+.rstudio-themes-light-menus .dialogTop .dialogTopCenter,
+.rstudio-themes-light-menus .gwt-DialogBox-ModalDialog,
+.rstudio-themes-light-menus .dataGridHeader,
+.rstudio-themes-dark-menus [id^="rstudio_dialog"],
+.rstudio-themes-dark-menus .dialogTop .dialogTopCenter,
+.rstudio-themes-dark-menus .gwt-DialogBox-ModalDialog,
+.rstudio-themes-dark-menus .dataGridHeader {
   /* outer border */
   border-color: #1e2234 !important;
 }
 
-.rstudio-themes-flat .dialogContent > table div,
-.rstudio-themes-flat .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
+.rstudio-themes-light-menus .dialogContent > table div,
+.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
+.rstudio-themes-dark-menus .dialogContent > table div,
+.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
   border-color: #1e2234;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelTab {
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab,
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab {
   border-color: #1e2234 !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelTab-selected div {
+.rstudio-themes-light-menus [id^="rstudio_label"][aria-selected="true"] div,
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab-selected div,
+.rstudio-themes-dark-menus [id^="rstudio_label"][aria-selected="true"] div,
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab-selected div {
   background-color: transparent !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-flat .dialogContent button table,
-.rstudio-themes-flat .dialogContent button:not(:hover) table > tbody > tr > td > div {
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table td,
+.rstudio-themes-light-menus .dialogContent button table,
+.rstudio-themes-light-menus .dialogContent button:not(:hover) table > tbody > tr > td > div,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table td,
+.rstudio-themes-dark-menus .dialogContent button table,
+.rstudio-themes-dark-menus .dialogContent button:not(:hover) table > tbody > tr > td > div {
   background: #151724 !important;
   color: #ffffff !important;
   border: none !important;
   box-shadow: none !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
   /* Dialog options lists and tabs */
   background: #151724 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
   background-color: #1e2234 !important;
   border-color: #1e2234 !important;
   color: #8F93A2 !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #8F93A2 !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
   color: #8F93A2 !important;
 }
 
-.rstudio-themes-flat .dialogContent button {
+.rstudio-themes-light-menus .dialogContent button,
+.rstudio-themes-dark-menus .dialogContent button {
   border-width: 2px !important;
   border-style: solid !important;
   border-color: #1e2234 !important;
   border-radius: 3px !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-flat .dialogContent button:hover,
-.rstudio-themes-flat .dialogContent button:hover table,
-.rstudio-themes-flat .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-flat .dialogContent button:hover table > tbody > tr > td > div {
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table div,
+.rstudio-themes-light-menus .dialogContent button:hover,
+.rstudio-themes-light-menus .dialogContent button:hover table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+.rstudio-themes-light-menus .dialogContent button:hover table > tbody > tr > td > div,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table div,
+.rstudio-themes-dark-menus .dialogContent button:hover,
+.rstudio-themes-dark-menus .dialogContent button:hover table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+.rstudio-themes-dark-menus .dialogContent button:hover table > tbody > tr > td > div {
   color: #8F93A2 !important;
   background: #272c44 !important;
   border-color: #1e2234 !important;
 }
 
-.rstudio-themes-flat .dialogContent input {
+.rstudio-themes-light-menus .dialogContent input,
+.rstudio-themes-dark-menus .dialogContent input {
   background: #151724 !important;
   color: #FFCB6B !important;
   border-color: #1e2234 !important;
 }
 
-.rstudio-themes-flat .dialogContent input[type="checkbox"] {
+.rstudio-themes-light-menus .dialogContent input[type="checkbox"],
+.rstudio-themes-dark-menus .dialogContent input[type="checkbox"] {
   background: #1e2234 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .dialogContent input[type="checkbox"]:checked::before {
+.rstudio-themes-light-menus .dialogContent input[type="checkbox"]:checked::before,
+.rstudio-themes-dark-menus .dialogContent input[type="checkbox"]:checked::before {
   content: "\2713" !important;
   color: #ffffff !important;
   vertical-align: top;
@@ -2903,31 +2977,37 @@ input#rstudio_command_palette_search {
   font-weight: 600;
 }
 
-.rstudio-themes-flat .dialogContent select {
+.rstudio-themes-light-menus .dialogContent select,
+.rstudio-themes-dark-menus .dialogContent select {
   background: #1e2234 !important;
   color: #ffffff !important;
 }
 
-.rstudio-themes-flat .rstudio-HyperlinkLabel {
+.rstudio-themes-light-menus .rstudio-HyperlinkLabel,
+.rstudio-themes-dark-menus .rstudio-HyperlinkLabel {
   color: #84FFFF;
 }
 
-.rstudio-themes-flat .search {
+.rstudio-themes-light-menus .search,
+.rstudio-themes-dark-menus .search {
   /* code search */
   background-color: #151724;
   color: #ffffff;
 }
 
-.rstudio-themes-flat .search .rstheme_center img {
+.rstudio-themes-light-menus .search .rstheme_center img,
+.rstudio-themes-dark-menus .search .rstheme_center img {
   display: none;
 }
 
-.rstudio-themes-flat .search .rstheme_center::before {
+.rstudio-themes-light-menus .search .rstheme_center::before,
+.rstudio-themes-dark-menus .search .rstheme_center::before {
   content: '\27a0';
   color: #ffffff;
 }
 
-.rstudio-themes-flat .search .rstheme_center > button::before {
+.rstudio-themes-light-menus .search .rstheme_center > button::before,
+.rstudio-themes-dark-menus .search .rstheme_center > button::before {
   content: '\2297';
   color: #ffffff;
   position: relative;
@@ -2935,7 +3015,8 @@ input#rstudio_command_palette_search {
   font-size: 1.25em;
 }
 
-.rstudio-themes-flat .search .rstheme_center > button:hover {
+.rstudio-themes-light-menus .search .rstheme_center > button:hover,
+.rstudio-themes-dark-menus .search .rstheme_center > button:hover {
   background: unset !important;
   border: unset !important;
 }

--- a/inst/themes/material-palenight.rstheme
+++ b/inst/themes/material-palenight.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: Material Palenight {rsthemes} */
 /* rs-theme-is-dark: TRUE */
@@ -17,26 +17,26 @@
   color: #FFFFFF;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #292D3E;
   color: #FFFFFF;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #292D3E;
   color: #FFFFFF;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #292D3E;
   color: #FFFFFF;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #FFFFFF;
 }
 
@@ -271,134 +271,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #232635 !important;
   color: #FFFFFF !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #232635 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #232635;
   border-color: #292D3E;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #292D3E;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #292D3E !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #676E95;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #292D3E !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #FFFFFF;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #292D3E !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #292D3E !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #4E5579 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #292D3E !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #84FFFF;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #292D3E !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #333747 !important;
   color: #FFFFFF !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #FFFFFF !important;
   background: #3A3F58 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #292D3E;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #292D3E;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #333747;
   color: #FFFFFF;
   border-color: #292D3E;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #292D3E;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #333747;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #FFFFFF;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #333747;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #3A3F58;
   color: #FFFFFF;
 }
@@ -412,15 +412,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #292D3E !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #292D3E !important;
 }
 
@@ -442,37 +442,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #252938 rgba(41, 45, 62, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(41, 45, 62, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #252938;
   border-radius: 0px;
   border: 2px solid #292D3E;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #2f3447;
 }
 
@@ -487,26 +487,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-flat .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
+.rstudio-themes-dark-menus .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
   border-color: #232635 !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
   border-color: #232635;
 }
 
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
   border-color: #232635;
 }
 
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
   border-color: #292D3E !important;
 }
 
 /* window containers */
-.rstudio-themes-flat
+.rstudio-themes-dark-menus
 > .rstudio-themes-dark
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -555,15 +555,16 @@ table.rstheme_tabLayoutCenter .gwt-Label,
   border: none;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected {
+  /* remove border from panes */
+}
+
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
   box-shadow: 0 -2px 0 #C792EA inset;
   border-radius: 0 !important;
 }
 
-/* remove border from panes */
-.rstudio-themes-flat
-:-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
-> div:last-child {
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected .rstudio-themes-dark-menus :-webkit-any(.windowframe, .rstheme_minimizedWindowObject) > div:last-child {
   border-color: #232635 !important;
 }
 
@@ -2700,202 +2701,275 @@ input#rstudio_command_palette_search {
   border-color: #292D3E;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #292D3E;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #292D3E;
   color: #FFFFFF;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #33384d;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3d435d;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
   height: 40px !important;
   background: #292D3E;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
   padding-left: 20px;
   padding-right: 20px;
   height: 40px;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
   vertical-align: middle !important;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
   height: 40px !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
+.rstudio-themes-light-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
   border-color: #292D3E !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
   display: none;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   display: inline-block;
   position: absolute !important;
   top: 0 !important;
   padding-left: 3px;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   padding-top: 5px;
 }
 
-.rstudio-themes-flat .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-flat .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
+.rstudio-themes-light-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
+.rstudio-themes-light-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
+.rstudio-themes-dark-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
   top: 38px !important;
 }
 
-.windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
+.rstudio-themes-light-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
+.rstudio-themes-dark-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
   height: 40px !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_dialog"],
-.rstudio-themes-flat :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-flat .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-flat .dialogTopCenter,
-.rstudio-themes-flat .dialogTop,
-.rstudio-themes-flat .dialogMiddle,
-.rstudio-themes-flat .dataGridHeader {
+.rstudio-themes-light-menus [id^="rstudio_dialog"],
+.rstudio-themes-light-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+.rstudio-themes-light-menus .dialogTopCenter,
+.rstudio-themes-light-menus .dialogTop,
+.rstudio-themes-light-menus .dialogMiddle,
+.rstudio-themes-light-menus .dataGridHeader,
+.rstudio-themes-dark-menus [id^="rstudio_dialog"],
+.rstudio-themes-dark-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+.rstudio-themes-dark-menus .dialogTopCenter,
+.rstudio-themes-dark-menus .dialogTop,
+.rstudio-themes-dark-menus .dialogMiddle,
+.rstudio-themes-dark-menus .dataGridHeader {
   background: #232635 !important;
   color: #FFFFFF !important;
 }
 
-.rstudio-themes-flat .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-flat .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
+.rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
+.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table,
+.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
   background: #232635 !important;
   color: #FFFFFF !important;
   border-color: #232635 !important;
 }
 
-.rstudio-themes-flat .dialogContent label.gwt-Label,
-.rstudio-themes-flat .dialogContent .gwt-RadioButton ~ * {
+.rstudio-themes-light-menus .dialogContent label.gwt-Label,
+.rstudio-themes-light-menus .dialogContent .gwt-RadioButton ~ *,
+.rstudio-themes-dark-menus .dialogContent label.gwt-Label,
+.rstudio-themes-dark-menus .dialogContent .gwt-RadioButton ~ * {
   color: #A6ACCD !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
   color: #C792EA !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_dialog"],
-.rstudio-themes-flat .dialogTop .dialogTopCenter,
-.rstudio-themes-flat .gwt-DialogBox-ModalDialog,
-.rstudio-themes-flat .dataGridHeader {
+.rstudio-themes-light-menus [id^="rstudio_dialog"],
+.rstudio-themes-light-menus .dialogTop .dialogTopCenter,
+.rstudio-themes-light-menus .gwt-DialogBox-ModalDialog,
+.rstudio-themes-light-menus .dataGridHeader,
+.rstudio-themes-dark-menus [id^="rstudio_dialog"],
+.rstudio-themes-dark-menus .dialogTop .dialogTopCenter,
+.rstudio-themes-dark-menus .gwt-DialogBox-ModalDialog,
+.rstudio-themes-dark-menus .dataGridHeader {
   /* outer border */
   border-color: #2d3144 !important;
 }
 
-.rstudio-themes-flat .dialogContent > table div,
-.rstudio-themes-flat .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
+.rstudio-themes-light-menus .dialogContent > table div,
+.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
+.rstudio-themes-dark-menus .dialogContent > table div,
+.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
   border-color: #2d3144;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelTab {
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab,
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab {
   border-color: #2d3144 !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelTab-selected div {
+.rstudio-themes-light-menus [id^="rstudio_label"][aria-selected="true"] div,
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab-selected div,
+.rstudio-themes-dark-menus [id^="rstudio_label"][aria-selected="true"] div,
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab-selected div {
   background-color: transparent !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-flat .dialogContent button table,
-.rstudio-themes-flat .dialogContent button:not(:hover) table > tbody > tr > td > div {
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table td,
+.rstudio-themes-light-menus .dialogContent button table,
+.rstudio-themes-light-menus .dialogContent button:not(:hover) table > tbody > tr > td > div,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table td,
+.rstudio-themes-dark-menus .dialogContent button table,
+.rstudio-themes-dark-menus .dialogContent button:not(:hover) table > tbody > tr > td > div {
   background: #232635 !important;
   color: #FFFFFF !important;
   border: none !important;
   box-shadow: none !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
   /* Dialog options lists and tabs */
   background: #232635 !important;
   color: #FFFFFF !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
   background-color: #2d3144 !important;
   border-color: #2d3144 !important;
   color: #A6ACCD !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #A6ACCD !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
   color: #A6ACCD !important;
 }
 
-.rstudio-themes-flat .dialogContent button {
+.rstudio-themes-light-menus .dialogContent button,
+.rstudio-themes-dark-menus .dialogContent button {
   border-width: 2px !important;
   border-style: solid !important;
   border-color: #2d3144 !important;
   border-radius: 3px !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-flat .dialogContent button:hover,
-.rstudio-themes-flat .dialogContent button:hover table,
-.rstudio-themes-flat .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-flat .dialogContent button:hover table > tbody > tr > td > div {
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table div,
+.rstudio-themes-light-menus .dialogContent button:hover,
+.rstudio-themes-light-menus .dialogContent button:hover table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+.rstudio-themes-light-menus .dialogContent button:hover table > tbody > tr > td > div,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table div,
+.rstudio-themes-dark-menus .dialogContent button:hover,
+.rstudio-themes-dark-menus .dialogContent button:hover table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+.rstudio-themes-dark-menus .dialogContent button:hover table > tbody > tr > td > div {
   color: #A6ACCD !important;
   background: #373d53 !important;
   border-color: #2d3144 !important;
 }
 
-.rstudio-themes-flat .dialogContent input {
+.rstudio-themes-light-menus .dialogContent input,
+.rstudio-themes-dark-menus .dialogContent input {
   background: #232635 !important;
   color: #FFCB6B !important;
   border-color: #2d3144 !important;
 }
 
-.rstudio-themes-flat .dialogContent input[type="checkbox"] {
+.rstudio-themes-light-menus .dialogContent input[type="checkbox"],
+.rstudio-themes-dark-menus .dialogContent input[type="checkbox"] {
   background: #2d3144 !important;
   color: #FFFFFF !important;
 }
 
-.rstudio-themes-flat .dialogContent input[type="checkbox"]:checked::before {
+.rstudio-themes-light-menus .dialogContent input[type="checkbox"]:checked::before,
+.rstudio-themes-dark-menus .dialogContent input[type="checkbox"]:checked::before {
   content: "\2713" !important;
   color: #FFFFFF !important;
   vertical-align: top;
@@ -2903,31 +2977,37 @@ input#rstudio_command_palette_search {
   font-weight: 600;
 }
 
-.rstudio-themes-flat .dialogContent select {
+.rstudio-themes-light-menus .dialogContent select,
+.rstudio-themes-dark-menus .dialogContent select {
   background: #2d3144 !important;
   color: #FFFFFF !important;
 }
 
-.rstudio-themes-flat .rstudio-HyperlinkLabel {
+.rstudio-themes-light-menus .rstudio-HyperlinkLabel,
+.rstudio-themes-dark-menus .rstudio-HyperlinkLabel {
   color: #C792EA;
 }
 
-.rstudio-themes-flat .search {
+.rstudio-themes-light-menus .search,
+.rstudio-themes-dark-menus .search {
   /* code search */
   background-color: #232635;
   color: #FFFFFF;
 }
 
-.rstudio-themes-flat .search .rstheme_center img {
+.rstudio-themes-light-menus .search .rstheme_center img,
+.rstudio-themes-dark-menus .search .rstheme_center img {
   display: none;
 }
 
-.rstudio-themes-flat .search .rstheme_center::before {
+.rstudio-themes-light-menus .search .rstheme_center::before,
+.rstudio-themes-dark-menus .search .rstheme_center::before {
   content: '\27a0';
   color: #FFFFFF;
 }
 
-.rstudio-themes-flat .search .rstheme_center > button::before {
+.rstudio-themes-light-menus .search .rstheme_center > button::before,
+.rstudio-themes-dark-menus .search .rstheme_center > button::before {
   content: '\2297';
   color: #FFFFFF;
   position: relative;
@@ -2935,7 +3015,8 @@ input#rstudio_command_palette_search {
   font-size: 1.25em;
 }
 
-.rstudio-themes-flat .search .rstheme_center > button:hover {
+.rstudio-themes-light-menus .search .rstheme_center > button:hover,
+.rstudio-themes-dark-menus .search .rstheme_center > button:hover {
   background: unset !important;
   border: unset !important;
 }

--- a/inst/themes/material-palenight.rstheme
+++ b/inst/themes/material-palenight.rstheme
@@ -17,26 +17,26 @@
   color: #FFFFFF;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #292D3E;
   color: #FFFFFF;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #292D3E;
   color: #FFFFFF;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #292D3E;
   color: #FFFFFF;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #FFFFFF;
 }
 
@@ -293,112 +293,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #292D3E !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #676E95;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #292D3E !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #FFFFFF;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #292D3E !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #292D3E !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #4E5579 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #292D3E !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #84FFFF;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #292D3E !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #333747 !important;
   color: #FFFFFF !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #FFFFFF !important;
   background: #3A3F58 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #292D3E;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #292D3E;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #333747;
   color: #FFFFFF;
   border-color: #292D3E;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #292D3E;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #333747;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #FFFFFF;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #333747;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #3A3F58;
   color: #FFFFFF;
 }
@@ -412,15 +412,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #292D3E !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #292D3E !important;
 }
 
@@ -442,37 +442,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #252938 rgba(41, 45, 62, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(41, 45, 62, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #252938;
   border-radius: 0px;
   border: 2px solid #292D3E;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #2f3447;
 }
 
@@ -487,26 +487,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-dark-menus .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
+body .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
   border-color: #232635 !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
   border-color: #232635;
 }
 
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
   border-color: #232635;
 }
 
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
   border-color: #292D3E !important;
 }
 
 /* window containers */
-.rstudio-themes-dark-menus
+body
 > .rstudio-themes-dark
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -2701,275 +2701,275 @@ input#rstudio_command_palette_search {
   border-color: #292D3E;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #292D3E;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #292D3E;
   color: #FFFFFF;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #33384d;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3d435d;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
   height: 40px !important;
   background: #292D3E;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
   padding-left: 20px;
   padding-right: 20px;
   height: 40px;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
   vertical-align: middle !important;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
   height: 40px !important;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
+body .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
+body .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
   border-color: #292D3E !important;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
   display: none;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   display: inline-block;
   position: absolute !important;
   top: 0 !important;
   padding-left: 3px;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   padding-top: 5px;
 }
 
-.rstudio-themes-light-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-light-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
-.rstudio-themes-dark-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
+body .windowframe .gwt-TabLayoutPanel > div:last-child,
+body .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
+body .windowframe .gwt-TabLayoutPanel > div:last-child,
+body .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
   top: 38px !important;
 }
 
-.rstudio-themes-light-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
-.rstudio-themes-dark-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
+body .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
+body .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
   height: 40px !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_dialog"],
-.rstudio-themes-light-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-light-menus .dialogTopCenter,
-.rstudio-themes-light-menus .dialogTop,
-.rstudio-themes-light-menus .dialogMiddle,
-.rstudio-themes-light-menus .dataGridHeader,
-.rstudio-themes-dark-menus [id^="rstudio_dialog"],
-.rstudio-themes-dark-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-dark-menus .dialogTopCenter,
-.rstudio-themes-dark-menus .dialogTop,
-.rstudio-themes-dark-menus .dialogMiddle,
-.rstudio-themes-dark-menus .dataGridHeader {
+body [id^="rstudio_dialog"],
+body :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+body .dialogTopCenter,
+body .dialogTop,
+body .dialogMiddle,
+body .dataGridHeader,
+body [id^="rstudio_dialog"],
+body :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+body .dialogTopCenter,
+body .dialogTop,
+body .dialogMiddle,
+body .dataGridHeader {
   background: #232635 !important;
   color: #FFFFFF !important;
 }
 
-.rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
-.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table,
-.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
+body .dialogContent > table:first-child:last-child :not(button) > table, body .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
+body .dialogContent > table:first-child:last-child :not(button) > table,
+body .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
   background: #232635 !important;
   color: #FFFFFF !important;
   border-color: #232635 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent label.gwt-Label,
-.rstudio-themes-light-menus .dialogContent .gwt-RadioButton ~ *,
-.rstudio-themes-dark-menus .dialogContent label.gwt-Label,
-.rstudio-themes-dark-menus .dialogContent .gwt-RadioButton ~ * {
+body .dialogContent label.gwt-Label,
+body .dialogContent .gwt-RadioButton ~ *,
+body .dialogContent label.gwt-Label,
+body .dialogContent .gwt-RadioButton ~ * {
   color: #A6ACCD !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
+body .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
+body .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
   color: #C792EA !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_dialog"],
-.rstudio-themes-light-menus .dialogTop .dialogTopCenter,
-.rstudio-themes-light-menus .gwt-DialogBox-ModalDialog,
-.rstudio-themes-light-menus .dataGridHeader,
-.rstudio-themes-dark-menus [id^="rstudio_dialog"],
-.rstudio-themes-dark-menus .dialogTop .dialogTopCenter,
-.rstudio-themes-dark-menus .gwt-DialogBox-ModalDialog,
-.rstudio-themes-dark-menus .dataGridHeader {
+body [id^="rstudio_dialog"],
+body .dialogTop .dialogTopCenter,
+body .gwt-DialogBox-ModalDialog,
+body .dataGridHeader,
+body [id^="rstudio_dialog"],
+body .dialogTop .dialogTopCenter,
+body .gwt-DialogBox-ModalDialog,
+body .dataGridHeader {
   /* outer border */
   border-color: #2d3144 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent > table div,
-.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
-.rstudio-themes-dark-menus .dialogContent > table div,
-.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
+body .dialogContent > table div,
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
+body .dialogContent > table div,
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
   border-color: #2d3144;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab,
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab {
+body .dialogContent .gwt-TabLayoutPanelTab,
+body .dialogContent .gwt-TabLayoutPanelTab {
   border-color: #2d3144 !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab-selected div,
-.rstudio-themes-dark-menus [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab-selected div {
+body [id^="rstudio_label"][aria-selected="true"] div,
+body .dialogContent .gwt-TabLayoutPanelTab-selected div,
+body [id^="rstudio_label"][aria-selected="true"] div,
+body .dialogContent .gwt-TabLayoutPanelTab-selected div {
   background-color: transparent !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-light-menus .dialogContent button table,
-.rstudio-themes-light-menus .dialogContent button:not(:hover) table > tbody > tr > td > div,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-dark-menus .dialogContent button table,
-.rstudio-themes-dark-menus .dialogContent button:not(:hover) table > tbody > tr > td > div {
+body .dialogContent .gwt-Button-DialogAction table,
+body .dialogContent .gwt-Button-DialogAction table td,
+body .dialogContent button table,
+body .dialogContent button:not(:hover) table > tbody > tr > td > div,
+body .dialogContent .gwt-Button-DialogAction table,
+body .dialogContent .gwt-Button-DialogAction table td,
+body .dialogContent button table,
+body .dialogContent button:not(:hover) table > tbody > tr > td > div {
   background: #232635 !important;
   color: #FFFFFF !important;
   border: none !important;
   box-shadow: none !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
+body .gwt-DialogBox .dialogContent [role="listbox"] > div,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [role="tablist"],
+body .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
+body .gwt-DialogBox .dialogContent [role="listbox"] > div,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [role="tablist"],
+body .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
   /* Dialog options lists and tabs */
   background: #232635 !important;
   color: #FFFFFF !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
   background-color: #2d3144 !important;
   border-color: #2d3144 !important;
   color: #A6ACCD !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #A6ACCD !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
   color: #A6ACCD !important;
 }
 
-.rstudio-themes-light-menus .dialogContent button,
-.rstudio-themes-dark-menus .dialogContent button {
+body .dialogContent button,
+body .dialogContent button {
   border-width: 2px !important;
   border-style: solid !important;
   border-color: #2d3144 !important;
   border-radius: 3px !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-light-menus .dialogContent button:hover,
-.rstudio-themes-light-menus .dialogContent button:hover table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-light-menus .dialogContent button:hover table > tbody > tr > td > div,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-dark-menus .dialogContent button:hover,
-.rstudio-themes-dark-menus .dialogContent button:hover table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-dark-menus .dialogContent button:hover table > tbody > tr > td > div {
+body .dialogContent .gwt-Button-DialogAction:hover table,
+body .dialogContent .gwt-Button-DialogAction:hover table div,
+body .dialogContent button:hover,
+body .dialogContent button:hover table,
+body .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+body .dialogContent button:hover table > tbody > tr > td > div,
+body .dialogContent .gwt-Button-DialogAction:hover table,
+body .dialogContent .gwt-Button-DialogAction:hover table div,
+body .dialogContent button:hover,
+body .dialogContent button:hover table,
+body .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+body .dialogContent button:hover table > tbody > tr > td > div {
   color: #A6ACCD !important;
   background: #373d53 !important;
   border-color: #2d3144 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input,
-.rstudio-themes-dark-menus .dialogContent input {
+body .dialogContent input,
+body .dialogContent input {
   background: #232635 !important;
   color: #FFCB6B !important;
   border-color: #2d3144 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input[type="checkbox"],
-.rstudio-themes-dark-menus .dialogContent input[type="checkbox"] {
+body .dialogContent input[type="checkbox"],
+body .dialogContent input[type="checkbox"] {
   background: #2d3144 !important;
   color: #FFFFFF !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input[type="checkbox"]:checked::before,
-.rstudio-themes-dark-menus .dialogContent input[type="checkbox"]:checked::before {
+body .dialogContent input[type="checkbox"]:checked::before,
+body .dialogContent input[type="checkbox"]:checked::before {
   content: "\2713" !important;
   color: #FFFFFF !important;
   vertical-align: top;
@@ -2977,37 +2977,37 @@ input#rstudio_command_palette_search {
   font-weight: 600;
 }
 
-.rstudio-themes-light-menus .dialogContent select,
-.rstudio-themes-dark-menus .dialogContent select {
+body .dialogContent select,
+body .dialogContent select {
   background: #2d3144 !important;
   color: #FFFFFF !important;
 }
 
-.rstudio-themes-light-menus .rstudio-HyperlinkLabel,
-.rstudio-themes-dark-menus .rstudio-HyperlinkLabel {
+body .rstudio-HyperlinkLabel,
+body .rstudio-HyperlinkLabel {
   color: #C792EA;
 }
 
-.rstudio-themes-light-menus .search,
-.rstudio-themes-dark-menus .search {
+body .search,
+body .search {
   /* code search */
   background-color: #232635;
   color: #FFFFFF;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center img,
-.rstudio-themes-dark-menus .search .rstheme_center img {
+body .search .rstheme_center img,
+body .search .rstheme_center img {
   display: none;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center::before,
-.rstudio-themes-dark-menus .search .rstheme_center::before {
+body .search .rstheme_center::before,
+body .search .rstheme_center::before {
   content: '\27a0';
   color: #FFFFFF;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center > button::before,
-.rstudio-themes-dark-menus .search .rstheme_center > button::before {
+body .search .rstheme_center > button::before,
+body .search .rstheme_center > button::before {
   content: '\2297';
   color: #FFFFFF;
   position: relative;
@@ -3015,8 +3015,8 @@ input#rstudio_command_palette_search {
   font-size: 1.25em;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center > button:hover,
-.rstudio-themes-dark-menus .search .rstheme_center > button:hover {
+body .search .rstheme_center > button:hover,
+body .search .rstheme_center > button:hover {
   background: unset !important;
   border: unset !important;
 }

--- a/inst/themes/material.rstheme
+++ b/inst/themes/material.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: Material {rsthemes} */
 /* rs-theme-is-dark: TRUE */
@@ -17,26 +17,26 @@
   color: #EEFFFF;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #263238;
   color: #EEFFFF;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #263238;
   color: #EEFFFF;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #263238;
   color: #EEFFFF;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #EEFFFF;
 }
 
@@ -271,134 +271,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #242f35 !important;
   color: #EEFFFF !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #242f35 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #242f35;
   border-color: #263238;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #263238;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #263238 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #607A86;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #263238 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #EEFFFF;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #263238 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #263238 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #546E7A !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #263238 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #84FFFF;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #263238 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #303C41 !important;
   color: #EEFFFF !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #EEFFFF !important;
   background: #37474F !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #263238;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #263238;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #303C41;
   color: #EEFFFF;
   border-color: #263238;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #263238;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #303C41;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #EEFFFF;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #303C41;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #37474F;
   color: #EEFFFF;
 }
@@ -412,15 +412,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #263238 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #263238 !important;
 }
 
@@ -442,37 +442,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #222d32 rgba(38, 50, 56, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(38, 50, 56, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #222d32;
   border-radius: 0px;
   border: 2px solid #263238;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #2c3a41;
 }
 
@@ -487,26 +487,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-flat .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
+.rstudio-themes-dark-menus .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
   border-color: #242f35 !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
   border-color: #242f35;
 }
 
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
   border-color: #242f35;
 }
 
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
   border-color: #263238 !important;
 }
 
 /* window containers */
-.rstudio-themes-flat
+.rstudio-themes-dark-menus
 > .rstudio-themes-dark
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -555,15 +555,16 @@ table.rstheme_tabLayoutCenter .gwt-Label,
   border: none;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected {
+  /* remove border from panes */
+}
+
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
   box-shadow: 0 -2px 0 #80CBC4 inset;
   border-radius: 0 !important;
 }
 
-/* remove border from panes */
-.rstudio-themes-flat
-:-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
-> div:last-child {
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected .rstudio-themes-dark-menus :-webkit-any(.windowframe, .rstheme_minimizedWindowObject) > div:last-child {
   border-color: #242f35 !important;
 }
 
@@ -2700,202 +2701,275 @@ input#rstudio_command_palette_search {
   border-color: #263238;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #263238;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #263238;
   color: #EEFFFF;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #304047;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3b4d56;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
   height: 40px !important;
   background: #263238;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
   padding-left: 20px;
   padding-right: 20px;
   height: 40px;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
   vertical-align: middle !important;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
   height: 40px !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
+.rstudio-themes-light-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
   border-color: #263238 !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
   display: none;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   display: inline-block;
   position: absolute !important;
   top: 0 !important;
   padding-left: 3px;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   padding-top: 5px;
 }
 
-.rstudio-themes-flat .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-flat .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
+.rstudio-themes-light-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
+.rstudio-themes-light-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
+.rstudio-themes-dark-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
   top: 38px !important;
 }
 
-.windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
+.rstudio-themes-light-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
+.rstudio-themes-dark-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
   height: 40px !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_dialog"],
-.rstudio-themes-flat :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-flat .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-flat .dialogTopCenter,
-.rstudio-themes-flat .dialogTop,
-.rstudio-themes-flat .dialogMiddle,
-.rstudio-themes-flat .dataGridHeader {
+.rstudio-themes-light-menus [id^="rstudio_dialog"],
+.rstudio-themes-light-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+.rstudio-themes-light-menus .dialogTopCenter,
+.rstudio-themes-light-menus .dialogTop,
+.rstudio-themes-light-menus .dialogMiddle,
+.rstudio-themes-light-menus .dataGridHeader,
+.rstudio-themes-dark-menus [id^="rstudio_dialog"],
+.rstudio-themes-dark-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+.rstudio-themes-dark-menus .dialogTopCenter,
+.rstudio-themes-dark-menus .dialogTop,
+.rstudio-themes-dark-menus .dialogMiddle,
+.rstudio-themes-dark-menus .dataGridHeader {
   background: #242f35 !important;
   color: #EEFFFF !important;
 }
 
-.rstudio-themes-flat .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-flat .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
+.rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
+.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table,
+.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
   background: #242f35 !important;
   color: #EEFFFF !important;
   border-color: #242f35 !important;
 }
 
-.rstudio-themes-flat .dialogContent label.gwt-Label,
-.rstudio-themes-flat .dialogContent .gwt-RadioButton ~ * {
+.rstudio-themes-light-menus .dialogContent label.gwt-Label,
+.rstudio-themes-light-menus .dialogContent .gwt-RadioButton ~ *,
+.rstudio-themes-dark-menus .dialogContent label.gwt-Label,
+.rstudio-themes-dark-menus .dialogContent .gwt-RadioButton ~ * {
   color: #B2CCD6 !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
   color: #80CBC4 !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_dialog"],
-.rstudio-themes-flat .dialogTop .dialogTopCenter,
-.rstudio-themes-flat .gwt-DialogBox-ModalDialog,
-.rstudio-themes-flat .dataGridHeader {
+.rstudio-themes-light-menus [id^="rstudio_dialog"],
+.rstudio-themes-light-menus .dialogTop .dialogTopCenter,
+.rstudio-themes-light-menus .gwt-DialogBox-ModalDialog,
+.rstudio-themes-light-menus .dataGridHeader,
+.rstudio-themes-dark-menus [id^="rstudio_dialog"],
+.rstudio-themes-dark-menus .dialogTop .dialogTopCenter,
+.rstudio-themes-dark-menus .gwt-DialogBox-ModalDialog,
+.rstudio-themes-dark-menus .dataGridHeader {
   /* outer border */
   border-color: #2e3d44 !important;
 }
 
-.rstudio-themes-flat .dialogContent > table div,
-.rstudio-themes-flat .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
+.rstudio-themes-light-menus .dialogContent > table div,
+.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
+.rstudio-themes-dark-menus .dialogContent > table div,
+.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
   border-color: #2e3d44;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelTab {
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab,
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab {
   border-color: #2e3d44 !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelTab-selected div {
+.rstudio-themes-light-menus [id^="rstudio_label"][aria-selected="true"] div,
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab-selected div,
+.rstudio-themes-dark-menus [id^="rstudio_label"][aria-selected="true"] div,
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab-selected div {
   background-color: transparent !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-flat .dialogContent button table,
-.rstudio-themes-flat .dialogContent button:not(:hover) table > tbody > tr > td > div {
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table td,
+.rstudio-themes-light-menus .dialogContent button table,
+.rstudio-themes-light-menus .dialogContent button:not(:hover) table > tbody > tr > td > div,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table td,
+.rstudio-themes-dark-menus .dialogContent button table,
+.rstudio-themes-dark-menus .dialogContent button:not(:hover) table > tbody > tr > td > div {
   background: #242f35 !important;
   color: #EEFFFF !important;
   border: none !important;
   box-shadow: none !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
   /* Dialog options lists and tabs */
   background: #242f35 !important;
   color: #EEFFFF !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
   background-color: #2e3d44 !important;
   border-color: #2e3d44 !important;
   color: #B2CCD6 !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #B2CCD6 !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
   color: #B2CCD6 !important;
 }
 
-.rstudio-themes-flat .dialogContent button {
+.rstudio-themes-light-menus .dialogContent button,
+.rstudio-themes-dark-menus .dialogContent button {
   border-width: 2px !important;
   border-style: solid !important;
   border-color: #2e3d44 !important;
   border-radius: 3px !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-flat .dialogContent button:hover,
-.rstudio-themes-flat .dialogContent button:hover table,
-.rstudio-themes-flat .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-flat .dialogContent button:hover table > tbody > tr > td > div {
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table div,
+.rstudio-themes-light-menus .dialogContent button:hover,
+.rstudio-themes-light-menus .dialogContent button:hover table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+.rstudio-themes-light-menus .dialogContent button:hover table > tbody > tr > td > div,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table div,
+.rstudio-themes-dark-menus .dialogContent button:hover,
+.rstudio-themes-dark-menus .dialogContent button:hover table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+.rstudio-themes-dark-menus .dialogContent button:hover table > tbody > tr > td > div {
   color: #B2CCD6 !important;
   background: #394a53 !important;
   border-color: #2e3d44 !important;
 }
 
-.rstudio-themes-flat .dialogContent input {
+.rstudio-themes-light-menus .dialogContent input,
+.rstudio-themes-dark-menus .dialogContent input {
   background: #242f35 !important;
   color: #FFCB6B !important;
   border-color: #2e3d44 !important;
 }
 
-.rstudio-themes-flat .dialogContent input[type="checkbox"] {
+.rstudio-themes-light-menus .dialogContent input[type="checkbox"],
+.rstudio-themes-dark-menus .dialogContent input[type="checkbox"] {
   background: #2e3d44 !important;
   color: #EEFFFF !important;
 }
 
-.rstudio-themes-flat .dialogContent input[type="checkbox"]:checked::before {
+.rstudio-themes-light-menus .dialogContent input[type="checkbox"]:checked::before,
+.rstudio-themes-dark-menus .dialogContent input[type="checkbox"]:checked::before {
   content: "\2713" !important;
   color: #EEFFFF !important;
   vertical-align: top;
@@ -2903,31 +2977,37 @@ input#rstudio_command_palette_search {
   font-weight: 600;
 }
 
-.rstudio-themes-flat .dialogContent select {
+.rstudio-themes-light-menus .dialogContent select,
+.rstudio-themes-dark-menus .dialogContent select {
   background: #2e3d44 !important;
   color: #EEFFFF !important;
 }
 
-.rstudio-themes-flat .rstudio-HyperlinkLabel {
+.rstudio-themes-light-menus .rstudio-HyperlinkLabel,
+.rstudio-themes-dark-menus .rstudio-HyperlinkLabel {
   color: #80CBC4;
 }
 
-.rstudio-themes-flat .search {
+.rstudio-themes-light-menus .search,
+.rstudio-themes-dark-menus .search {
   /* code search */
   background-color: #242f35;
   color: #EEFFFF;
 }
 
-.rstudio-themes-flat .search .rstheme_center img {
+.rstudio-themes-light-menus .search .rstheme_center img,
+.rstudio-themes-dark-menus .search .rstheme_center img {
   display: none;
 }
 
-.rstudio-themes-flat .search .rstheme_center::before {
+.rstudio-themes-light-menus .search .rstheme_center::before,
+.rstudio-themes-dark-menus .search .rstheme_center::before {
   content: '\27a0';
   color: #EEFFFF;
 }
 
-.rstudio-themes-flat .search .rstheme_center > button::before {
+.rstudio-themes-light-menus .search .rstheme_center > button::before,
+.rstudio-themes-dark-menus .search .rstheme_center > button::before {
   content: '\2297';
   color: #EEFFFF;
   position: relative;
@@ -2935,7 +3015,8 @@ input#rstudio_command_palette_search {
   font-size: 1.25em;
 }
 
-.rstudio-themes-flat .search .rstheme_center > button:hover {
+.rstudio-themes-light-menus .search .rstheme_center > button:hover,
+.rstudio-themes-dark-menus .search .rstheme_center > button:hover {
   background: unset !important;
   border: unset !important;
 }

--- a/inst/themes/material.rstheme
+++ b/inst/themes/material.rstheme
@@ -17,26 +17,26 @@
   color: #EEFFFF;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #263238;
   color: #EEFFFF;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #263238;
   color: #EEFFFF;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #263238;
   color: #EEFFFF;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #EEFFFF;
 }
 
@@ -293,112 +293,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #263238 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #607A86;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #263238 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #EEFFFF;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #263238 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #263238 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #546E7A !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #263238 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #84FFFF;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #263238 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #303C41 !important;
   color: #EEFFFF !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #EEFFFF !important;
   background: #37474F !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #263238;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #263238;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #303C41;
   color: #EEFFFF;
   border-color: #263238;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #263238;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #303C41;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #EEFFFF;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #303C41;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #37474F;
   color: #EEFFFF;
 }
@@ -412,15 +412,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #263238 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #263238 !important;
 }
 
@@ -442,37 +442,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #222d32 rgba(38, 50, 56, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(38, 50, 56, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #222d32;
   border-radius: 0px;
   border: 2px solid #263238;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #2c3a41;
 }
 
@@ -487,26 +487,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-dark-menus .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
+body .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
   border-color: #242f35 !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
   border-color: #242f35;
 }
 
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
   border-color: #242f35;
 }
 
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
   border-color: #263238 !important;
 }
 
 /* window containers */
-.rstudio-themes-dark-menus
+body
 > .rstudio-themes-dark
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -2701,275 +2701,275 @@ input#rstudio_command_palette_search {
   border-color: #263238;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #263238;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #263238;
   color: #EEFFFF;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #304047;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3b4d56;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
   height: 40px !important;
   background: #263238;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
   padding-left: 20px;
   padding-right: 20px;
   height: 40px;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
   vertical-align: middle !important;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
   height: 40px !important;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
+body .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
+body .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
   border-color: #263238 !important;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
   display: none;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   display: inline-block;
   position: absolute !important;
   top: 0 !important;
   padding-left: 3px;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   padding-top: 5px;
 }
 
-.rstudio-themes-light-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-light-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
-.rstudio-themes-dark-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
+body .windowframe .gwt-TabLayoutPanel > div:last-child,
+body .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
+body .windowframe .gwt-TabLayoutPanel > div:last-child,
+body .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
   top: 38px !important;
 }
 
-.rstudio-themes-light-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
-.rstudio-themes-dark-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
+body .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
+body .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
   height: 40px !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_dialog"],
-.rstudio-themes-light-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-light-menus .dialogTopCenter,
-.rstudio-themes-light-menus .dialogTop,
-.rstudio-themes-light-menus .dialogMiddle,
-.rstudio-themes-light-menus .dataGridHeader,
-.rstudio-themes-dark-menus [id^="rstudio_dialog"],
-.rstudio-themes-dark-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-dark-menus .dialogTopCenter,
-.rstudio-themes-dark-menus .dialogTop,
-.rstudio-themes-dark-menus .dialogMiddle,
-.rstudio-themes-dark-menus .dataGridHeader {
+body [id^="rstudio_dialog"],
+body :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+body .dialogTopCenter,
+body .dialogTop,
+body .dialogMiddle,
+body .dataGridHeader,
+body [id^="rstudio_dialog"],
+body :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+body .dialogTopCenter,
+body .dialogTop,
+body .dialogMiddle,
+body .dataGridHeader {
   background: #242f35 !important;
   color: #EEFFFF !important;
 }
 
-.rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
-.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table,
-.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
+body .dialogContent > table:first-child:last-child :not(button) > table, body .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
+body .dialogContent > table:first-child:last-child :not(button) > table,
+body .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
   background: #242f35 !important;
   color: #EEFFFF !important;
   border-color: #242f35 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent label.gwt-Label,
-.rstudio-themes-light-menus .dialogContent .gwt-RadioButton ~ *,
-.rstudio-themes-dark-menus .dialogContent label.gwt-Label,
-.rstudio-themes-dark-menus .dialogContent .gwt-RadioButton ~ * {
+body .dialogContent label.gwt-Label,
+body .dialogContent .gwt-RadioButton ~ *,
+body .dialogContent label.gwt-Label,
+body .dialogContent .gwt-RadioButton ~ * {
   color: #B2CCD6 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
+body .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
+body .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
   color: #80CBC4 !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_dialog"],
-.rstudio-themes-light-menus .dialogTop .dialogTopCenter,
-.rstudio-themes-light-menus .gwt-DialogBox-ModalDialog,
-.rstudio-themes-light-menus .dataGridHeader,
-.rstudio-themes-dark-menus [id^="rstudio_dialog"],
-.rstudio-themes-dark-menus .dialogTop .dialogTopCenter,
-.rstudio-themes-dark-menus .gwt-DialogBox-ModalDialog,
-.rstudio-themes-dark-menus .dataGridHeader {
+body [id^="rstudio_dialog"],
+body .dialogTop .dialogTopCenter,
+body .gwt-DialogBox-ModalDialog,
+body .dataGridHeader,
+body [id^="rstudio_dialog"],
+body .dialogTop .dialogTopCenter,
+body .gwt-DialogBox-ModalDialog,
+body .dataGridHeader {
   /* outer border */
   border-color: #2e3d44 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent > table div,
-.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
-.rstudio-themes-dark-menus .dialogContent > table div,
-.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
+body .dialogContent > table div,
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
+body .dialogContent > table div,
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
   border-color: #2e3d44;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab,
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab {
+body .dialogContent .gwt-TabLayoutPanelTab,
+body .dialogContent .gwt-TabLayoutPanelTab {
   border-color: #2e3d44 !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab-selected div,
-.rstudio-themes-dark-menus [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab-selected div {
+body [id^="rstudio_label"][aria-selected="true"] div,
+body .dialogContent .gwt-TabLayoutPanelTab-selected div,
+body [id^="rstudio_label"][aria-selected="true"] div,
+body .dialogContent .gwt-TabLayoutPanelTab-selected div {
   background-color: transparent !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-light-menus .dialogContent button table,
-.rstudio-themes-light-menus .dialogContent button:not(:hover) table > tbody > tr > td > div,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-dark-menus .dialogContent button table,
-.rstudio-themes-dark-menus .dialogContent button:not(:hover) table > tbody > tr > td > div {
+body .dialogContent .gwt-Button-DialogAction table,
+body .dialogContent .gwt-Button-DialogAction table td,
+body .dialogContent button table,
+body .dialogContent button:not(:hover) table > tbody > tr > td > div,
+body .dialogContent .gwt-Button-DialogAction table,
+body .dialogContent .gwt-Button-DialogAction table td,
+body .dialogContent button table,
+body .dialogContent button:not(:hover) table > tbody > tr > td > div {
   background: #242f35 !important;
   color: #EEFFFF !important;
   border: none !important;
   box-shadow: none !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
+body .gwt-DialogBox .dialogContent [role="listbox"] > div,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [role="tablist"],
+body .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
+body .gwt-DialogBox .dialogContent [role="listbox"] > div,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [role="tablist"],
+body .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
   /* Dialog options lists and tabs */
   background: #242f35 !important;
   color: #EEFFFF !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
   background-color: #2e3d44 !important;
   border-color: #2e3d44 !important;
   color: #B2CCD6 !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #B2CCD6 !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
   color: #B2CCD6 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent button,
-.rstudio-themes-dark-menus .dialogContent button {
+body .dialogContent button,
+body .dialogContent button {
   border-width: 2px !important;
   border-style: solid !important;
   border-color: #2e3d44 !important;
   border-radius: 3px !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-light-menus .dialogContent button:hover,
-.rstudio-themes-light-menus .dialogContent button:hover table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-light-menus .dialogContent button:hover table > tbody > tr > td > div,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-dark-menus .dialogContent button:hover,
-.rstudio-themes-dark-menus .dialogContent button:hover table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-dark-menus .dialogContent button:hover table > tbody > tr > td > div {
+body .dialogContent .gwt-Button-DialogAction:hover table,
+body .dialogContent .gwt-Button-DialogAction:hover table div,
+body .dialogContent button:hover,
+body .dialogContent button:hover table,
+body .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+body .dialogContent button:hover table > tbody > tr > td > div,
+body .dialogContent .gwt-Button-DialogAction:hover table,
+body .dialogContent .gwt-Button-DialogAction:hover table div,
+body .dialogContent button:hover,
+body .dialogContent button:hover table,
+body .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+body .dialogContent button:hover table > tbody > tr > td > div {
   color: #B2CCD6 !important;
   background: #394a53 !important;
   border-color: #2e3d44 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input,
-.rstudio-themes-dark-menus .dialogContent input {
+body .dialogContent input,
+body .dialogContent input {
   background: #242f35 !important;
   color: #FFCB6B !important;
   border-color: #2e3d44 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input[type="checkbox"],
-.rstudio-themes-dark-menus .dialogContent input[type="checkbox"] {
+body .dialogContent input[type="checkbox"],
+body .dialogContent input[type="checkbox"] {
   background: #2e3d44 !important;
   color: #EEFFFF !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input[type="checkbox"]:checked::before,
-.rstudio-themes-dark-menus .dialogContent input[type="checkbox"]:checked::before {
+body .dialogContent input[type="checkbox"]:checked::before,
+body .dialogContent input[type="checkbox"]:checked::before {
   content: "\2713" !important;
   color: #EEFFFF !important;
   vertical-align: top;
@@ -2977,37 +2977,37 @@ input#rstudio_command_palette_search {
   font-weight: 600;
 }
 
-.rstudio-themes-light-menus .dialogContent select,
-.rstudio-themes-dark-menus .dialogContent select {
+body .dialogContent select,
+body .dialogContent select {
   background: #2e3d44 !important;
   color: #EEFFFF !important;
 }
 
-.rstudio-themes-light-menus .rstudio-HyperlinkLabel,
-.rstudio-themes-dark-menus .rstudio-HyperlinkLabel {
+body .rstudio-HyperlinkLabel,
+body .rstudio-HyperlinkLabel {
   color: #80CBC4;
 }
 
-.rstudio-themes-light-menus .search,
-.rstudio-themes-dark-menus .search {
+body .search,
+body .search {
   /* code search */
   background-color: #242f35;
   color: #EEFFFF;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center img,
-.rstudio-themes-dark-menus .search .rstheme_center img {
+body .search .rstheme_center img,
+body .search .rstheme_center img {
   display: none;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center::before,
-.rstudio-themes-dark-menus .search .rstheme_center::before {
+body .search .rstheme_center::before,
+body .search .rstheme_center::before {
   content: '\27a0';
   color: #EEFFFF;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center > button::before,
-.rstudio-themes-dark-menus .search .rstheme_center > button::before {
+body .search .rstheme_center > button::before,
+body .search .rstheme_center > button::before {
   content: '\2297';
   color: #EEFFFF;
   position: relative;
@@ -3015,8 +3015,8 @@ input#rstudio_command_palette_search {
   font-size: 1.25em;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center > button:hover,
-.rstudio-themes-dark-menus .search .rstheme_center > button:hover {
+body .search .rstheme_center > button:hover,
+body .search .rstheme_center > button:hover {
   background: unset !important;
   border: unset !important;
 }

--- a/inst/themes/night-owl.rstheme
+++ b/inst/themes/night-owl.rstheme
@@ -17,26 +17,26 @@
   color: #d6deeb;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #011627;
   color: #d6deeb;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #011627;
   color: #d6deeb;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #011627;
   color: #d6deeb;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #d6deeb;
 }
 
@@ -293,112 +293,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #011421 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: rgba(214, 222, 235, 0.6);
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #162a3a !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #d6deeb;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #010E17 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #162a3a !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #d6deeb !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #162a3a !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #ff2c83;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #162a3a !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #010E17 !important;
   color: #d6deeb !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #d6deeb !important;
   background: #645081 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #010E17;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #010E17;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #010E17;
   color: #d6deeb;
   border-color: #010E17;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #010E17;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #010E17;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #d6deeb;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #010E17;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #645081;
   color: #d6deeb;
 }
@@ -412,15 +412,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #011421 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #011421 !important;
 }
 
@@ -442,37 +442,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #162a3a rgba(1, 22, 39, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(1, 22, 39, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #162a3a;
   border-radius: 0px;
   border: 2px solid #011627;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #1d374c;
 }
 
@@ -487,26 +487,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-dark-menus .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
+body .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
   border-color: #010E17 !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
   border-color: #010E17;
 }
 
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
   border-color: #010E17;
 }
 
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
   border-color: #011627 !important;
 }
 
 /* window containers */
-.rstudio-themes-dark-menus
+body
 > .rstudio-themes-dark
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -555,12 +555,12 @@ table.rstheme_tabLayoutCenter .gwt-Label,
   border: none;
 }
 
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
+body .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
   box-shadow: 0 4px 0 #3465a4 inset;
   border-radius: 0 !important;
 }
 
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter .gwt-Label {
+body .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter .gwt-Label {
   font-weight: 600;
 }
 
@@ -2697,275 +2697,275 @@ input#rstudio_command_palette_search {
   border-color: #011627;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #011627;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #011627;
   color: #d6deeb;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #3c3b62;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #645489;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
   height: 40px !important;
   background: #011421;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
   padding-left: 20px;
   padding-right: 20px;
   height: 40px;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
   vertical-align: middle !important;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
   height: 40px !important;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
+body .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
+body .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
   border-color: #011421 !important;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
   display: none;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   display: inline-block;
   position: absolute !important;
   top: 0 !important;
   padding-left: 3px;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   padding-top: 5px;
 }
 
-.rstudio-themes-light-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-light-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
-.rstudio-themes-dark-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
+body .windowframe .gwt-TabLayoutPanel > div:last-child,
+body .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
+body .windowframe .gwt-TabLayoutPanel > div:last-child,
+body .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
   top: 38px !important;
 }
 
-.rstudio-themes-light-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
-.rstudio-themes-dark-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
+body .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
+body .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
   height: 40px !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_dialog"],
-.rstudio-themes-light-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-light-menus .dialogTopCenter,
-.rstudio-themes-light-menus .dialogTop,
-.rstudio-themes-light-menus .dialogMiddle,
-.rstudio-themes-light-menus .dataGridHeader,
-.rstudio-themes-dark-menus [id^="rstudio_dialog"],
-.rstudio-themes-dark-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-dark-menus .dialogTopCenter,
-.rstudio-themes-dark-menus .dialogTop,
-.rstudio-themes-dark-menus .dialogMiddle,
-.rstudio-themes-dark-menus .dataGridHeader {
+body [id^="rstudio_dialog"],
+body :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+body .dialogTopCenter,
+body .dialogTop,
+body .dialogMiddle,
+body .dataGridHeader,
+body [id^="rstudio_dialog"],
+body :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+body .dialogTopCenter,
+body .dialogTop,
+body .dialogMiddle,
+body .dataGridHeader {
   background: #010E17 !important;
   color: #6c7a89 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
-.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table,
-.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
+body .dialogContent > table:first-child:last-child :not(button) > table, body .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
+body .dialogContent > table:first-child:last-child :not(button) > table,
+body .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
   background: #010E17 !important;
   color: #6c7a89 !important;
   border-color: #010E17 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent label.gwt-Label,
-.rstudio-themes-light-menus .dialogContent .gwt-RadioButton ~ *,
-.rstudio-themes-dark-menus .dialogContent label.gwt-Label,
-.rstudio-themes-dark-menus .dialogContent .gwt-RadioButton ~ * {
+body .dialogContent label.gwt-Label,
+body .dialogContent .gwt-RadioButton ~ *,
+body .dialogContent label.gwt-Label,
+body .dialogContent .gwt-RadioButton ~ * {
   color: #5ca7e4 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
+body .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
+body .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
   color: #7fdbca !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_dialog"],
-.rstudio-themes-light-menus .dialogTop .dialogTopCenter,
-.rstudio-themes-light-menus .gwt-DialogBox-ModalDialog,
-.rstudio-themes-light-menus .dataGridHeader,
-.rstudio-themes-dark-menus [id^="rstudio_dialog"],
-.rstudio-themes-dark-menus .dialogTop .dialogTopCenter,
-.rstudio-themes-dark-menus .gwt-DialogBox-ModalDialog,
-.rstudio-themes-dark-menus .dataGridHeader {
+body [id^="rstudio_dialog"],
+body .dialogTop .dialogTopCenter,
+body .gwt-DialogBox-ModalDialog,
+body .dataGridHeader,
+body [id^="rstudio_dialog"],
+body .dialogTop .dialogTopCenter,
+body .gwt-DialogBox-ModalDialog,
+body .dataGridHeader {
   /* outer border */
   border-color: #021d2f !important;
 }
 
-.rstudio-themes-light-menus .dialogContent > table div,
-.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
-.rstudio-themes-dark-menus .dialogContent > table div,
-.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
+body .dialogContent > table div,
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
+body .dialogContent > table div,
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
   border-color: #021d2f;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab,
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab {
+body .dialogContent .gwt-TabLayoutPanelTab,
+body .dialogContent .gwt-TabLayoutPanelTab {
   border-color: #021d2f !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab-selected div,
-.rstudio-themes-dark-menus [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab-selected div {
+body [id^="rstudio_label"][aria-selected="true"] div,
+body .dialogContent .gwt-TabLayoutPanelTab-selected div,
+body [id^="rstudio_label"][aria-selected="true"] div,
+body .dialogContent .gwt-TabLayoutPanelTab-selected div {
   background-color: transparent !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-light-menus .dialogContent button table,
-.rstudio-themes-light-menus .dialogContent button:not(:hover) table > tbody > tr > td > div,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-dark-menus .dialogContent button table,
-.rstudio-themes-dark-menus .dialogContent button:not(:hover) table > tbody > tr > td > div {
+body .dialogContent .gwt-Button-DialogAction table,
+body .dialogContent .gwt-Button-DialogAction table td,
+body .dialogContent button table,
+body .dialogContent button:not(:hover) table > tbody > tr > td > div,
+body .dialogContent .gwt-Button-DialogAction table,
+body .dialogContent .gwt-Button-DialogAction table td,
+body .dialogContent button table,
+body .dialogContent button:not(:hover) table > tbody > tr > td > div {
   background: #010E17 !important;
   color: #6c7a89 !important;
   border: none !important;
   box-shadow: none !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
+body .gwt-DialogBox .dialogContent [role="listbox"] > div,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [role="tablist"],
+body .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
+body .gwt-DialogBox .dialogContent [role="listbox"] > div,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [role="tablist"],
+body .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
   /* Dialog options lists and tabs */
   background: #010E17 !important;
   color: #6c7a89 !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
   background-color: #3c3b62 !important;
   border-color: #3c3b62 !important;
   color: #d6deeb !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #d6deeb !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
   color: #d6deeb !important;
 }
 
-.rstudio-themes-light-menus .dialogContent button,
-.rstudio-themes-dark-menus .dialogContent button {
+body .dialogContent button,
+body .dialogContent button {
   border-width: 2px !important;
   border-style: solid !important;
   border-color: #021d2f !important;
   border-radius: 3px !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-light-menus .dialogContent button:hover,
-.rstudio-themes-light-menus .dialogContent button:hover table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-light-menus .dialogContent button:hover table > tbody > tr > td > div,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-dark-menus .dialogContent button:hover,
-.rstudio-themes-dark-menus .dialogContent button:hover table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-dark-menus .dialogContent button:hover table > tbody > tr > td > div {
+body .dialogContent .gwt-Button-DialogAction:hover table,
+body .dialogContent .gwt-Button-DialogAction:hover table div,
+body .dialogContent button:hover,
+body .dialogContent button:hover table,
+body .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+body .dialogContent button:hover table > tbody > tr > td > div,
+body .dialogContent .gwt-Button-DialogAction:hover table,
+body .dialogContent .gwt-Button-DialogAction:hover table div,
+body .dialogContent button:hover,
+body .dialogContent button:hover table,
+body .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+body .dialogContent button:hover table > tbody > tr > td > div {
   color: #8794a1 !important;
   background: #032c48 !important;
   border-color: #021d2f !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input,
-.rstudio-themes-dark-menus .dialogContent input {
+body .dialogContent input,
+body .dialogContent input {
   background: #011627 !important;
   color: #d6deeb !important;
   border-color: #021d2f !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input[type="checkbox"],
-.rstudio-themes-dark-menus .dialogContent input[type="checkbox"] {
+body .dialogContent input[type="checkbox"],
+body .dialogContent input[type="checkbox"] {
   background: #011627 !important;
   color: #addb67 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input[type="checkbox"]:checked::before,
-.rstudio-themes-dark-menus .dialogContent input[type="checkbox"]:checked::before {
+body .dialogContent input[type="checkbox"]:checked::before,
+body .dialogContent input[type="checkbox"]:checked::before {
   content: "\2713" !important;
   color: #addb67 !important;
   vertical-align: top;
@@ -2973,37 +2973,37 @@ input#rstudio_command_palette_search {
   font-weight: 600;
 }
 
-.rstudio-themes-light-menus .dialogContent select,
-.rstudio-themes-dark-menus .dialogContent select {
+body .dialogContent select,
+body .dialogContent select {
   background: #021d2f !important;
   color: #d6deeb !important;
 }
 
-.rstudio-themes-light-menus .rstudio-HyperlinkLabel,
-.rstudio-themes-dark-menus .rstudio-HyperlinkLabel {
+body .rstudio-HyperlinkLabel,
+body .rstudio-HyperlinkLabel {
   color: #7fdbca;
 }
 
-.rstudio-themes-light-menus .search,
-.rstudio-themes-dark-menus .search {
+body .search,
+body .search {
   /* code search */
   background-color: #010E17;
   color: #6c7a89;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center img,
-.rstudio-themes-dark-menus .search .rstheme_center img {
+body .search .rstheme_center img,
+body .search .rstheme_center img {
   display: none;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center::before,
-.rstudio-themes-dark-menus .search .rstheme_center::before {
+body .search .rstheme_center::before,
+body .search .rstheme_center::before {
   content: '\27a0';
   color: #6c7a89;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center > button::before,
-.rstudio-themes-dark-menus .search .rstheme_center > button::before {
+body .search .rstheme_center > button::before,
+body .search .rstheme_center > button::before {
   content: '\2297';
   color: #6c7a89;
   position: relative;
@@ -3011,8 +3011,8 @@ input#rstudio_command_palette_search {
   font-size: 1.25em;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center > button:hover,
-.rstudio-themes-dark-menus .search .rstheme_center > button:hover {
+body .search .rstheme_center > button:hover,
+body .search .rstheme_center > button:hover {
   background: unset !important;
   border: unset !important;
 }

--- a/inst/themes/night-owl.rstheme
+++ b/inst/themes/night-owl.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: Night Owl {rsthemes} */
 /* rs-theme-is-dark: TRUE */
@@ -17,26 +17,26 @@
   color: #d6deeb;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #011627;
   color: #d6deeb;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #011627;
   color: #d6deeb;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #011627;
   color: #d6deeb;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #d6deeb;
 }
 
@@ -271,134 +271,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #010E17 !important;
   color: #6c7a89 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #010E17 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #010E17;
   border-color: #011627;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #011627;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #011421 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: rgba(214, 222, 235, 0.6);
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #162a3a !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #d6deeb;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #010E17 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #162a3a !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #d6deeb !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #162a3a !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #ff2c83;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #162a3a !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #010E17 !important;
   color: #d6deeb !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #d6deeb !important;
   background: #645081 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #010E17;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #010E17;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #010E17;
   color: #d6deeb;
   border-color: #010E17;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #010E17;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #010E17;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #d6deeb;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #010E17;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #645081;
   color: #d6deeb;
 }
@@ -412,15 +412,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #011421 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #011421 !important;
 }
 
@@ -442,37 +442,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #162a3a rgba(1, 22, 39, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(1, 22, 39, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #162a3a;
   border-radius: 0px;
   border: 2px solid #011627;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #1d374c;
 }
 
@@ -487,26 +487,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-flat .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
+.rstudio-themes-dark-menus .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
   border-color: #010E17 !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
   border-color: #010E17;
 }
 
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
   border-color: #010E17;
 }
 
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
   border-color: #011627 !important;
 }
 
 /* window containers */
-.rstudio-themes-flat
+.rstudio-themes-dark-menus
 > .rstudio-themes-dark
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -555,12 +555,12 @@ table.rstheme_tabLayoutCenter .gwt-Label,
   border: none;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
   box-shadow: 0 4px 0 #3465a4 inset;
   border-radius: 0 !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter .gwt-Label {
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter .gwt-Label {
   font-weight: 600;
 }
 
@@ -2697,202 +2697,275 @@ input#rstudio_command_palette_search {
   border-color: #011627;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #011627;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #011627;
   color: #d6deeb;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #3c3b62;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #645489;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
   height: 40px !important;
   background: #011421;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
   padding-left: 20px;
   padding-right: 20px;
   height: 40px;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
   vertical-align: middle !important;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
   height: 40px !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
+.rstudio-themes-light-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
   border-color: #011421 !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
   display: none;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   display: inline-block;
   position: absolute !important;
   top: 0 !important;
   padding-left: 3px;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   padding-top: 5px;
 }
 
-.rstudio-themes-flat .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-flat .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
+.rstudio-themes-light-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
+.rstudio-themes-light-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
+.rstudio-themes-dark-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
   top: 38px !important;
 }
 
-.windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
+.rstudio-themes-light-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
+.rstudio-themes-dark-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
   height: 40px !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_dialog"],
-.rstudio-themes-flat :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-flat .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-flat .dialogTopCenter,
-.rstudio-themes-flat .dialogTop,
-.rstudio-themes-flat .dialogMiddle,
-.rstudio-themes-flat .dataGridHeader {
+.rstudio-themes-light-menus [id^="rstudio_dialog"],
+.rstudio-themes-light-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+.rstudio-themes-light-menus .dialogTopCenter,
+.rstudio-themes-light-menus .dialogTop,
+.rstudio-themes-light-menus .dialogMiddle,
+.rstudio-themes-light-menus .dataGridHeader,
+.rstudio-themes-dark-menus [id^="rstudio_dialog"],
+.rstudio-themes-dark-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+.rstudio-themes-dark-menus .dialogTopCenter,
+.rstudio-themes-dark-menus .dialogTop,
+.rstudio-themes-dark-menus .dialogMiddle,
+.rstudio-themes-dark-menus .dataGridHeader {
   background: #010E17 !important;
   color: #6c7a89 !important;
 }
 
-.rstudio-themes-flat .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-flat .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
+.rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
+.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table,
+.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
   background: #010E17 !important;
   color: #6c7a89 !important;
   border-color: #010E17 !important;
 }
 
-.rstudio-themes-flat .dialogContent label.gwt-Label,
-.rstudio-themes-flat .dialogContent .gwt-RadioButton ~ * {
+.rstudio-themes-light-menus .dialogContent label.gwt-Label,
+.rstudio-themes-light-menus .dialogContent .gwt-RadioButton ~ *,
+.rstudio-themes-dark-menus .dialogContent label.gwt-Label,
+.rstudio-themes-dark-menus .dialogContent .gwt-RadioButton ~ * {
   color: #5ca7e4 !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
   color: #7fdbca !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_dialog"],
-.rstudio-themes-flat .dialogTop .dialogTopCenter,
-.rstudio-themes-flat .gwt-DialogBox-ModalDialog,
-.rstudio-themes-flat .dataGridHeader {
+.rstudio-themes-light-menus [id^="rstudio_dialog"],
+.rstudio-themes-light-menus .dialogTop .dialogTopCenter,
+.rstudio-themes-light-menus .gwt-DialogBox-ModalDialog,
+.rstudio-themes-light-menus .dataGridHeader,
+.rstudio-themes-dark-menus [id^="rstudio_dialog"],
+.rstudio-themes-dark-menus .dialogTop .dialogTopCenter,
+.rstudio-themes-dark-menus .gwt-DialogBox-ModalDialog,
+.rstudio-themes-dark-menus .dataGridHeader {
   /* outer border */
   border-color: #021d2f !important;
 }
 
-.rstudio-themes-flat .dialogContent > table div,
-.rstudio-themes-flat .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
+.rstudio-themes-light-menus .dialogContent > table div,
+.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
+.rstudio-themes-dark-menus .dialogContent > table div,
+.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
   border-color: #021d2f;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelTab {
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab,
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab {
   border-color: #021d2f !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelTab-selected div {
+.rstudio-themes-light-menus [id^="rstudio_label"][aria-selected="true"] div,
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab-selected div,
+.rstudio-themes-dark-menus [id^="rstudio_label"][aria-selected="true"] div,
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab-selected div {
   background-color: transparent !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-flat .dialogContent button table,
-.rstudio-themes-flat .dialogContent button:not(:hover) table > tbody > tr > td > div {
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table td,
+.rstudio-themes-light-menus .dialogContent button table,
+.rstudio-themes-light-menus .dialogContent button:not(:hover) table > tbody > tr > td > div,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table td,
+.rstudio-themes-dark-menus .dialogContent button table,
+.rstudio-themes-dark-menus .dialogContent button:not(:hover) table > tbody > tr > td > div {
   background: #010E17 !important;
   color: #6c7a89 !important;
   border: none !important;
   box-shadow: none !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
   /* Dialog options lists and tabs */
   background: #010E17 !important;
   color: #6c7a89 !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
   background-color: #3c3b62 !important;
   border-color: #3c3b62 !important;
   color: #d6deeb !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #d6deeb !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
   color: #d6deeb !important;
 }
 
-.rstudio-themes-flat .dialogContent button {
+.rstudio-themes-light-menus .dialogContent button,
+.rstudio-themes-dark-menus .dialogContent button {
   border-width: 2px !important;
   border-style: solid !important;
   border-color: #021d2f !important;
   border-radius: 3px !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-flat .dialogContent button:hover,
-.rstudio-themes-flat .dialogContent button:hover table,
-.rstudio-themes-flat .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-flat .dialogContent button:hover table > tbody > tr > td > div {
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table div,
+.rstudio-themes-light-menus .dialogContent button:hover,
+.rstudio-themes-light-menus .dialogContent button:hover table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+.rstudio-themes-light-menus .dialogContent button:hover table > tbody > tr > td > div,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table div,
+.rstudio-themes-dark-menus .dialogContent button:hover,
+.rstudio-themes-dark-menus .dialogContent button:hover table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+.rstudio-themes-dark-menus .dialogContent button:hover table > tbody > tr > td > div {
   color: #8794a1 !important;
   background: #032c48 !important;
   border-color: #021d2f !important;
 }
 
-.rstudio-themes-flat .dialogContent input {
+.rstudio-themes-light-menus .dialogContent input,
+.rstudio-themes-dark-menus .dialogContent input {
   background: #011627 !important;
   color: #d6deeb !important;
   border-color: #021d2f !important;
 }
 
-.rstudio-themes-flat .dialogContent input[type="checkbox"] {
+.rstudio-themes-light-menus .dialogContent input[type="checkbox"],
+.rstudio-themes-dark-menus .dialogContent input[type="checkbox"] {
   background: #011627 !important;
   color: #addb67 !important;
 }
 
-.rstudio-themes-flat .dialogContent input[type="checkbox"]:checked::before {
+.rstudio-themes-light-menus .dialogContent input[type="checkbox"]:checked::before,
+.rstudio-themes-dark-menus .dialogContent input[type="checkbox"]:checked::before {
   content: "\2713" !important;
   color: #addb67 !important;
   vertical-align: top;
@@ -2900,31 +2973,37 @@ input#rstudio_command_palette_search {
   font-weight: 600;
 }
 
-.rstudio-themes-flat .dialogContent select {
+.rstudio-themes-light-menus .dialogContent select,
+.rstudio-themes-dark-menus .dialogContent select {
   background: #021d2f !important;
   color: #d6deeb !important;
 }
 
-.rstudio-themes-flat .rstudio-HyperlinkLabel {
+.rstudio-themes-light-menus .rstudio-HyperlinkLabel,
+.rstudio-themes-dark-menus .rstudio-HyperlinkLabel {
   color: #7fdbca;
 }
 
-.rstudio-themes-flat .search {
+.rstudio-themes-light-menus .search,
+.rstudio-themes-dark-menus .search {
   /* code search */
   background-color: #010E17;
   color: #6c7a89;
 }
 
-.rstudio-themes-flat .search .rstheme_center img {
+.rstudio-themes-light-menus .search .rstheme_center img,
+.rstudio-themes-dark-menus .search .rstheme_center img {
   display: none;
 }
 
-.rstudio-themes-flat .search .rstheme_center::before {
+.rstudio-themes-light-menus .search .rstheme_center::before,
+.rstudio-themes-dark-menus .search .rstheme_center::before {
   content: '\27a0';
   color: #6c7a89;
 }
 
-.rstudio-themes-flat .search .rstheme_center > button::before {
+.rstudio-themes-light-menus .search .rstheme_center > button::before,
+.rstudio-themes-dark-menus .search .rstheme_center > button::before {
   content: '\2297';
   color: #6c7a89;
   position: relative;
@@ -2932,7 +3011,8 @@ input#rstudio_command_palette_search {
   font-size: 1.25em;
 }
 
-.rstudio-themes-flat .search .rstheme_center > button:hover {
+.rstudio-themes-light-menus .search .rstheme_center > button:hover,
+.rstudio-themes-dark-menus .search .rstheme_center > button:hover {
   background: unset !important;
   border: unset !important;
 }

--- a/inst/themes/nord-polar-night-aurora.rstheme
+++ b/inst/themes/nord-polar-night-aurora.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: Nord Polar Night Aurora {rsthemes} */
 /* rs-theme-is-dark: TRUE */
@@ -17,26 +17,26 @@
   color: #d8dee9;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #2e3440;
   color: #d8dee9;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #2e3440;
   color: #d8dee9;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #2e3440;
   color: #d8dee9;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #d8dee9;
 }
 
@@ -271,134 +271,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #2a2f3a !important;
   color: #d8dee9 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #2a2f3a !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #2a2f3a;
   border-color: #2e3440;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #2e3440;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #3b4252 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: rgba(216, 222, 233, 0.6);
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #434c5e !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #e5e9f0;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #3b4252 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #434c5e !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #d8dee9 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #434c5e !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d08770;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #434c5e !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #2e3440 !important;
   color: #d8dee9 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #d8dee9 !important;
   background: #4c566a !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #46597c;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #46597c;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #2e3440;
   color: #d8dee9;
   border-color: #46597c;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #46597c;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #2e3440;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #d8dee9;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #2e3440;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #4c566a;
   color: #d8dee9;
 }
@@ -412,15 +412,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #3b4252 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #3b4252 !important;
 }
 
@@ -442,37 +442,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #3b4252 rgba(46, 52, 64, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(46, 52, 64, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #3b4252;
   border-radius: 0px;
   border: 2px solid #2e3440;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #464e61;
 }
 
@@ -487,26 +487,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-flat .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
+.rstudio-themes-dark-menus .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
   border-color: #2a2f3a !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
   border-color: #2a2f3a;
 }
 
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
   border-color: #2a2f3a;
 }
 
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
   border-color: #2e3440 !important;
 }
 
 /* window containers */
-.rstudio-themes-flat
+.rstudio-themes-dark-menus
 > .rstudio-themes-dark
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -567,35 +567,49 @@ input#rstudio_command_palette_search {
   border-color: #2e3440;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #2e3440;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #2e3440;
   color: #d8dee9;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #39404f;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #434c5e;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/nord-polar-night-aurora.rstheme
+++ b/inst/themes/nord-polar-night-aurora.rstheme
@@ -17,26 +17,26 @@
   color: #d8dee9;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #2e3440;
   color: #d8dee9;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #2e3440;
   color: #d8dee9;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #2e3440;
   color: #d8dee9;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #d8dee9;
 }
 
@@ -293,112 +293,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #3b4252 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: rgba(216, 222, 233, 0.6);
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #434c5e !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #e5e9f0;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #3b4252 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #434c5e !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #d8dee9 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #434c5e !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d08770;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #434c5e !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #2e3440 !important;
   color: #d8dee9 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #d8dee9 !important;
   background: #4c566a !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #46597c;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #46597c;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #2e3440;
   color: #d8dee9;
   border-color: #46597c;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #46597c;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #2e3440;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #d8dee9;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #2e3440;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #4c566a;
   color: #d8dee9;
 }
@@ -412,15 +412,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #3b4252 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #3b4252 !important;
 }
 
@@ -442,37 +442,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #3b4252 rgba(46, 52, 64, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(46, 52, 64, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #3b4252;
   border-radius: 0px;
   border: 2px solid #2e3440;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #464e61;
 }
 
@@ -487,26 +487,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-dark-menus .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
+body .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
   border-color: #2a2f3a !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
   border-color: #2a2f3a;
 }
 
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
   border-color: #2a2f3a;
 }
 
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
   border-color: #2e3440 !important;
 }
 
 /* window containers */
-.rstudio-themes-dark-menus
+body
 > .rstudio-themes-dark
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -567,49 +567,49 @@ input#rstudio_command_palette_search {
   border-color: #2e3440;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #2e3440;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #2e3440;
   color: #d8dee9;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #39404f;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #434c5e;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/nord-snow-storm.rstheme
+++ b/inst/themes/nord-snow-storm.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: Nord Snow Storm {rsthemes} */
 /* rs-theme-is-dark: FALSE */
@@ -17,35 +17,35 @@
   color: #4c566a;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-light-menus.ace_editor_theme {
   background-color: white;
   color: #4c566a;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
   background-color: white;
   color: #4c566a;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-light-menus .ace_editor_theme {
   background-color: white !important;
   color: #4c566a !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table {
+.rstudio-themes-light-menus .ace_editor_theme table {
   background-color: white !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table thead > tr > th {
+.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
   background-color: white !important;
 }
 
-.rstudio-themes-flat.ace_editor_theme a {
+.rstudio-themes-light-menus.ace_editor_theme a {
   color: #4c566a !important;
   font-weight: bold;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-light-menus .gwt-Label {
   color: #4c566a;
 }
 
@@ -310,148 +310,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   background: #f9fafb !important;
   color: #4c566a !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
   background: #f9fafb !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #f9fafb;
   border-color: white;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
   border-color: white;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #d8dee9 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: rgba(76, 86, 106, 0.6);
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-default .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #eceff4 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #434c5e;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #d8dee9 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper {
   background: #eceff4 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
   color: #4c566a !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .search, .rstudio-themes-flat.rstudio-themes-default-menus .search {
+.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
   /* search */
   background: #eceff4 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d08770;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
   background: #eceff4 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-light-menus .popupMiddleCenter,
+.rstudio-themes-light-menus .menuPopupMiddleCenter,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter {
   background: white !important;
   color: #4c566a !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #4c566a !important;
   background: #d8dee9 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-light-menus .themedPopupPanel {
   border: solid 1px rgba(208, 135, 112, 0.4);
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px rgba(208, 135, 112, 0.4);
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-light-menus .popupContent {
   background: white;
   color: #4c566a;
   border-color: rgba(208, 135, 112, 0.4);
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: rgba(208, 135, 112, 0.4);
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
   background: white;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
   background: #4c566a;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: white;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #d8dee9;
   color: #4c566a;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #d8dee9 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #d8dee9 !important;
 }
 
@@ -473,36 +473,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-light-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #eceff4 rgba(255, 255, 255, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(255, 255, 255, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #eceff4;
   border-radius: 0px;
   border: 2px solid white;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #dce1eb;
 }
 
@@ -517,26 +517,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-flat table.rstudio-themes-background td > div:first-child {
+.rstudio-themes-light-menus table.rstudio-themes-background td > div:first-child {
   border-color: #f9fafb !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-flat > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
+.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
   border-color: #f9fafb;
 }
 
-.rstudio-themes-flat > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   border-color: #f9fafb;
 }
 
-.rstudio-themes-flat > .rstudio-themes-default .gwt-SplitLayoutPanel td {
+.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel td {
   border-color: white !important;
 }
 
 /* window containers */
-.rstudio-themes-flat
+.rstudio-themes-light-menus
 > .rstudio-themes-default
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -596,35 +596,49 @@ input#rstudio_command_palette_search {
   border-color: white;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: white;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: white;
   color: #4c566a;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #eff1f6;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #dfe4ec;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/nord-snow-storm.rstheme
+++ b/inst/themes/nord-snow-storm.rstheme
@@ -17,35 +17,35 @@
   color: #4c566a;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: white;
   color: #4c566a;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: white;
   color: #4c566a;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: white !important;
   color: #4c566a !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table {
+body .ace_editor_theme table {
   background-color: white !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
+body .ace_editor_theme table thead > tr > th {
   background-color: white !important;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme a {
+body.ace_editor_theme a {
   color: #4c566a !important;
   font-weight: bold;
 }
 
-.rstudio-themes-light-menus .gwt-Label {
+body .gwt-Label {
   color: #4c566a;
 }
 
@@ -310,148 +310,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   background: #f9fafb !important;
   color: #4c566a !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
+body .rstudio-themes-default .rstudio-themes-background {
   background: #f9fafb !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+body .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+body .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #f9fafb;
   border-color: white;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
+body .rstudio-themes-default .rstudio-themes-border {
   border-color: white;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #d8dee9 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: rgba(76, 86, 106, 0.6);
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-default .rstheme_center,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #eceff4 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #434c5e;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #d8dee9 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #eceff4 !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #4c566a !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
+body .search, body.rstudio-themes-default-menus .search {
   /* search */
   background: #eceff4 !important;
 }
 
-.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #d08770;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
+.rstheme_secondaryToolbar, body .dataGridHeader {
   background: #eceff4 !important;
 }
 
 /* menu background */
-.rstudio-themes-light-menus .popupMiddleCenter,
-.rstudio-themes-light-menus .menuPopupMiddleCenter,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: white !important;
   color: #4c566a !important;
 }
 
-.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #4c566a !important;
   background: #d8dee9 !important;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px rgba(208, 135, 112, 0.4);
 }
 
-.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px rgba(208, 135, 112, 0.4);
 }
 
-.rstudio-themes-light-menus .popupContent {
+body .popupContent {
   background: white;
   color: #4c566a;
   border-color: rgba(208, 135, 112, 0.4);
 }
 
-.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: rgba(208, 135, 112, 0.4);
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: white;
   padding: 2px;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #4c566a;
   border: 0;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: white;
 }
 
-.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #d8dee9;
   color: #4c566a;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #d8dee9 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #d8dee9 !important;
 }
 
@@ -473,36 +473,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-light-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
+body, body .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #eceff4 rgba(255, 255, 255, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(255, 255, 255, 0.5);
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #eceff4;
   border-radius: 0px;
   border: 2px solid white;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #dce1eb;
 }
 
@@ -517,26 +517,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-light-menus table.rstudio-themes-background td > div:first-child {
+body table.rstudio-themes-background td > div:first-child {
   border-color: #f9fafb !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
+body > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
   border-color: #f9fafb;
 }
 
-.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   border-color: #f9fafb;
 }
 
-.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel td {
+body > .rstudio-themes-default .gwt-SplitLayoutPanel td {
   border-color: white !important;
 }
 
 /* window containers */
-.rstudio-themes-light-menus
+body
 > .rstudio-themes-default
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -596,49 +596,49 @@ input#rstudio_command_palette_search {
   border-color: white;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: white;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: white;
   color: #4c566a;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #eff1f6;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #dfe4ec;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/oceanic-plus.rstheme
+++ b/inst/themes/oceanic-plus.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: Oceanic Plus {rsthemes} */
 /* rs-theme-is-dark: TRUE */
@@ -18,26 +18,26 @@
   color: #D8DEE9;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #1B2B34;
   color: #D8DEE9;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #1B2B34;
   color: #D8DEE9;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #1B2B34;
   color: #D8DEE9;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #D8DEE9;
 }
 
@@ -272,134 +272,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #343D46 !important;
   color: #D8DEE9 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #343D46 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #343D46;
   border-color: #1B2B34;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #1B2B34;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #343D46 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #A7ADBA;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #4F5B66 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #D8DEE9;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #343D46 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #4F5B66 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #D8DEE9 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #4F5B66 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #AB7967;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #4F5B66 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #1B2B34 !important;
   color: #D8DEE9 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #D8DEE9 !important;
   background: #4F5B66 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #4F5B66;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #4F5B66;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #1B2B34;
   color: #D8DEE9;
   border-color: #4F5B66;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #4F5B66;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #1B2B34;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #D8DEE9;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1B2B34;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #4F5B66;
   color: #D8DEE9;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #343D46 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #343D46 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #343D46 rgba(27, 43, 52, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(27, 43, 52, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #343D46;
   border-radius: 0px;
   border: 2px solid #1B2B34;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #3f4a55;
 }
 
@@ -488,26 +488,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-flat .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
+.rstudio-themes-dark-menus .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
   border-color: #343D46 !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
   border-color: #343D46;
 }
 
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
   border-color: #343D46;
 }
 
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
   border-color: #1B2B34 !important;
 }
 
 /* window containers */
-.rstudio-themes-flat
+.rstudio-themes-dark-menus
 > .rstudio-themes-dark
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -568,35 +568,49 @@ input#rstudio_command_palette_search {
   border-color: #1B2B34;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #1B2B34;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1B2B34;
   color: #D8DEE9;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #243945;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #2c4756;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/oceanic-plus.rstheme
+++ b/inst/themes/oceanic-plus.rstheme
@@ -18,26 +18,26 @@
   color: #D8DEE9;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #1B2B34;
   color: #D8DEE9;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #1B2B34;
   color: #D8DEE9;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #1B2B34;
   color: #D8DEE9;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #D8DEE9;
 }
 
@@ -294,112 +294,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #343D46 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #A7ADBA;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #4F5B66 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #D8DEE9;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #343D46 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #4F5B66 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #D8DEE9 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #4F5B66 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #AB7967;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #4F5B66 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #1B2B34 !important;
   color: #D8DEE9 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #D8DEE9 !important;
   background: #4F5B66 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #4F5B66;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #4F5B66;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #1B2B34;
   color: #D8DEE9;
   border-color: #4F5B66;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #4F5B66;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #1B2B34;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #D8DEE9;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1B2B34;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #4F5B66;
   color: #D8DEE9;
 }
@@ -413,15 +413,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #343D46 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #343D46 !important;
 }
 
@@ -443,37 +443,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #343D46 rgba(27, 43, 52, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(27, 43, 52, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #343D46;
   border-radius: 0px;
   border: 2px solid #1B2B34;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #3f4a55;
 }
 
@@ -488,26 +488,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-dark-menus .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
+body .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
   border-color: #343D46 !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
   border-color: #343D46;
 }
 
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
   border-color: #343D46;
 }
 
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
   border-color: #1B2B34 !important;
 }
 
 /* window containers */
-.rstudio-themes-dark-menus
+body
 > .rstudio-themes-dark
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -568,49 +568,49 @@ input#rstudio_command_palette_search {
   border-color: #1B2B34;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #1B2B34;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #1B2B34;
   color: #D8DEE9;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #243945;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #2c4756;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/one-dark.rstheme
+++ b/inst/themes/one-dark.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: One Dark {rsthemes} */
 /* rs-theme-is-dark: TRUE */
@@ -17,26 +17,26 @@
   color: #abb2bf;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #282c34;
   color: #abb2bf;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #282c34;
   color: #abb2bf;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #282c34;
   color: #abb2bf;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #abb2bf;
 }
 
@@ -271,134 +271,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #21252b !important;
   color: #abb2bf !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #21252b !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #21252b;
   border-color: #282c34;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #282c34;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #21252b !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: rgba(171, 178, 191, 0.5);
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #282c34 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #abb2bf;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #21252b !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #282c34 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #abb2bf !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #282c34 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #e06c75;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #282c34 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #282c34 !important;
   color: #abb2bf !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #abb2bf !important;
   background: rgba(22, 24, 29, 0.6) !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px rgba(82, 139, 255, 0.4);
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px rgba(82, 139, 255, 0.4);
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #282c34;
   color: #abb2bf;
   border-color: rgba(82, 139, 255, 0.4);
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: rgba(82, 139, 255, 0.4);
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #282c34;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #abb2bf;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #282c34;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: rgba(22, 24, 29, 0.6);
   color: #abb2bf;
 }
@@ -412,15 +412,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #21252b !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #21252b !important;
 }
 
@@ -442,37 +442,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #24272e rgba(40, 44, 52, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(40, 44, 52, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #24272e;
   border-radius: 0px;
   border: 2px solid #282c34;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #2f333d;
 }
 
@@ -487,26 +487,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-flat .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
+.rstudio-themes-dark-menus .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
   border-color: #21252b !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
   border-color: #21252b;
 }
 
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
   border-color: #21252b;
 }
 
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
   border-color: #282c34 !important;
 }
 
 /* window containers */
-.rstudio-themes-flat
+.rstudio-themes-dark-menus
 > .rstudio-themes-dark
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -567,35 +567,49 @@ input#rstudio_command_palette_search {
   border-color: #282c34;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #282c34;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #282c34;
   color: #abb2bf;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #333842;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3e4451;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 
@@ -2750,7 +2764,7 @@ input#rstudio_command_palette_search {
 }
 
 /* window containers */
-.rstudio-themes-flat
+.rstudio-themes-dark-menus
 > .rstudio-themes-dark
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {

--- a/inst/themes/one-dark.rstheme
+++ b/inst/themes/one-dark.rstheme
@@ -17,26 +17,26 @@
   color: #abb2bf;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #282c34;
   color: #abb2bf;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #282c34;
   color: #abb2bf;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #282c34;
   color: #abb2bf;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #abb2bf;
 }
 
@@ -293,112 +293,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #21252b !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: rgba(171, 178, 191, 0.5);
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #282c34 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #abb2bf;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #21252b !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #282c34 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #abb2bf !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #282c34 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #e06c75;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #282c34 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #282c34 !important;
   color: #abb2bf !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #abb2bf !important;
   background: rgba(22, 24, 29, 0.6) !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px rgba(82, 139, 255, 0.4);
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px rgba(82, 139, 255, 0.4);
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #282c34;
   color: #abb2bf;
   border-color: rgba(82, 139, 255, 0.4);
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: rgba(82, 139, 255, 0.4);
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #282c34;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #abb2bf;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #282c34;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: rgba(22, 24, 29, 0.6);
   color: #abb2bf;
 }
@@ -412,15 +412,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #21252b !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #21252b !important;
 }
 
@@ -442,37 +442,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #24272e rgba(40, 44, 52, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(40, 44, 52, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #24272e;
   border-radius: 0px;
   border: 2px solid #282c34;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #2f333d;
 }
 
@@ -487,26 +487,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-dark-menus .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
+body .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
   border-color: #21252b !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
   border-color: #21252b;
 }
 
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
   border-color: #21252b;
 }
 
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
   border-color: #282c34 !important;
 }
 
 /* window containers */
-.rstudio-themes-dark-menus
+body
 > .rstudio-themes-dark
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -567,49 +567,49 @@ input#rstudio_command_palette_search {
   border-color: #282c34;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #282c34;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #282c34;
   color: #abb2bf;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #333842;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3e4451;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 
@@ -2764,7 +2764,7 @@ input#rstudio_command_palette_search {
 }
 
 /* window containers */
-.rstudio-themes-dark-menus
+body
 > .rstudio-themes-dark
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {

--- a/inst/themes/one-light.rstheme
+++ b/inst/themes/one-light.rstheme
@@ -17,35 +17,35 @@
   color: #383a42;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #fafafa;
   color: #383a42;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #fafafa;
   color: #383a42;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #fafafa !important;
   color: #383a42 !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table {
+body .ace_editor_theme table {
   background-color: #fafafa !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
+body .ace_editor_theme table thead > tr > th {
   background-color: #fafafa !important;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme a {
+body.ace_editor_theme a {
   color: #383a42 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-light-menus .gwt-Label {
+body .gwt-Label {
   color: #383a42;
 }
 
@@ -310,148 +310,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   background: whitesmoke !important;
   color: #383a42 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
+body .rstudio-themes-default .rstudio-themes-background {
   background: whitesmoke !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+body .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+body .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: whitesmoke;
   border-color: #fafafa;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
+body .rstudio-themes-default .rstudio-themes-border {
   border-color: #fafafa;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #fafafa !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: rgba(56, 58, 66, 0.6);
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-default .rstheme_center,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #ededed !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #383a42;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #fafafa !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #ededed !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #383a42 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
+body .search, body.rstudio-themes-default-menus .search {
   /* search */
   background: #ededed !important;
 }
 
-.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #e45649;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
+.rstheme_secondaryToolbar, body .dataGridHeader {
   background: #ededed !important;
 }
 
 /* menu background */
-.rstudio-themes-light-menus .popupMiddleCenter,
-.rstudio-themes-light-menus .menuPopupMiddleCenter,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #fafafa !important;
   color: #383a42 !important;
 }
 
-.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #383a42 !important;
   background: rgba(160, 161, 167, 0.4) !important;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px rgba(82, 111, 255, 0.4);
 }
 
-.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px rgba(82, 111, 255, 0.4);
 }
 
-.rstudio-themes-light-menus .popupContent {
+body .popupContent {
   background: #fafafa;
   color: #383a42;
   border-color: rgba(82, 111, 255, 0.4);
 }
 
-.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: rgba(82, 111, 255, 0.4);
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #fafafa;
   padding: 2px;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #383a42;
   border: 0;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #fafafa;
 }
 
-.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: rgba(160, 161, 167, 0.4);
   color: #383a42;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #fafafa !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #fafafa !important;
 }
 
@@ -473,36 +473,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-light-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
+body, body .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #ededed rgba(250, 250, 250, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(250, 250, 250, 0.5);
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #ededed;
   border-radius: 0px;
   border: 2px solid #fafafa;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #e1e1e1;
 }
 
@@ -517,26 +517,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-light-menus table.rstudio-themes-background td > div:first-child {
+body table.rstudio-themes-background td > div:first-child {
   border-color: whitesmoke !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
+body > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
   border-color: whitesmoke;
 }
 
-.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   border-color: whitesmoke;
 }
 
-.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel td {
+body > .rstudio-themes-default .gwt-SplitLayoutPanel td {
   border-color: #fafafa !important;
 }
 
 /* window containers */
-.rstudio-themes-light-menus
+body
 > .rstudio-themes-default
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -596,49 +596,49 @@ input#rstudio_command_palette_search {
   border-color: #fafafa;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #fafafa;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #fafafa;
   color: #383a42;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #ededed;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #e1e1e1;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/one-light.rstheme
+++ b/inst/themes/one-light.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: One Light {rsthemes} */
 /* rs-theme-is-dark: FALSE */
@@ -17,35 +17,35 @@
   color: #383a42;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-light-menus.ace_editor_theme {
   background-color: #fafafa;
   color: #383a42;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #fafafa;
   color: #383a42;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-light-menus .ace_editor_theme {
   background-color: #fafafa !important;
   color: #383a42 !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table {
+.rstudio-themes-light-menus .ace_editor_theme table {
   background-color: #fafafa !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table thead > tr > th {
+.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
   background-color: #fafafa !important;
 }
 
-.rstudio-themes-flat.ace_editor_theme a {
+.rstudio-themes-light-menus.ace_editor_theme a {
   color: #383a42 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-light-menus .gwt-Label {
   color: #383a42;
 }
 
@@ -310,148 +310,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   background: whitesmoke !important;
   color: #383a42 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
   background: whitesmoke !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: whitesmoke;
   border-color: #fafafa;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
   border-color: #fafafa;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #fafafa !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: rgba(56, 58, 66, 0.6);
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-default .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #ededed !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #383a42;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #fafafa !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper {
   background: #ededed !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
   color: #383a42 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .search, .rstudio-themes-flat.rstudio-themes-default-menus .search {
+.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
   /* search */
   background: #ededed !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #e45649;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
   background: #ededed !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-light-menus .popupMiddleCenter,
+.rstudio-themes-light-menus .menuPopupMiddleCenter,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter {
   background: #fafafa !important;
   color: #383a42 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #383a42 !important;
   background: rgba(160, 161, 167, 0.4) !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-light-menus .themedPopupPanel {
   border: solid 1px rgba(82, 111, 255, 0.4);
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px rgba(82, 111, 255, 0.4);
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-light-menus .popupContent {
   background: #fafafa;
   color: #383a42;
   border-color: rgba(82, 111, 255, 0.4);
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: rgba(82, 111, 255, 0.4);
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
   background: #fafafa;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
   background: #383a42;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #fafafa;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: rgba(160, 161, 167, 0.4);
   color: #383a42;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #fafafa !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #fafafa !important;
 }
 
@@ -473,36 +473,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-light-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #ededed rgba(250, 250, 250, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(250, 250, 250, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #ededed;
   border-radius: 0px;
   border: 2px solid #fafafa;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #e1e1e1;
 }
 
@@ -517,26 +517,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-flat table.rstudio-themes-background td > div:first-child {
+.rstudio-themes-light-menus table.rstudio-themes-background td > div:first-child {
   border-color: whitesmoke !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-flat > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
+.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
   border-color: whitesmoke;
 }
 
-.rstudio-themes-flat > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   border-color: whitesmoke;
 }
 
-.rstudio-themes-flat > .rstudio-themes-default .gwt-SplitLayoutPanel td {
+.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel td {
   border-color: #fafafa !important;
 }
 
 /* window containers */
-.rstudio-themes-flat
+.rstudio-themes-light-menus
 > .rstudio-themes-default
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -596,35 +596,49 @@ input#rstudio_command_palette_search {
   border-color: #fafafa;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #fafafa;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #fafafa;
   color: #383a42;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #ededed;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #e1e1e1;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/serendipity-dark.rstheme
+++ b/inst/themes/serendipity-dark.rstheme
@@ -17,26 +17,26 @@
   color: #cbccc6;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #222733;
   color: #cbccc6;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #222733;
   color: #cbccc6;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #222733;
   color: #cbccc6;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #cbccc6;
 }
 
@@ -293,112 +293,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #1f2430 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #cbccc6;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #222733 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #cbccc6;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #232936 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #222733 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #cbccc6 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #222733 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #aa87e5;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #222733 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #1d212b !important;
   color: #cbccc6 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #cbccc6 !important;
   background: #374c5f !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #ededed;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #ededed;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #1d212b;
   color: #cbccc6;
   border-color: #ededed;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #ededed;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #1d212b;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #cbccc6;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1d212b;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #374c5f;
   color: #cbccc6;
 }
@@ -412,15 +412,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #1f2430 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #1f2430 !important;
 }
 
@@ -442,37 +442,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #1f2430 rgba(34, 39, 51, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(34, 39, 51, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #1f2430;
   border-radius: 0px;
   border: 2px solid #222733;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #29303f;
 }
 
@@ -487,26 +487,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-dark-menus .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
+body .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
   border-color: #1d212b !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
   border-color: #1d212b;
 }
 
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
   border-color: #1d212b;
 }
 
-.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
+body > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
   border-color: #222733 !important;
 }
 
 /* window containers */
-.rstudio-themes-dark-menus
+body
 > .rstudio-themes-dark
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -567,7 +567,7 @@ table.rstheme_tabLayoutCenter .gwt-Label,
   font-style: italic;
 }
 
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
+body .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
   box-shadow: 0 2px 0 #f06897 inset;
   border-radius: 0 !important;
 }
@@ -2705,275 +2705,275 @@ input#rstudio_command_palette_search {
   border-color: #222733;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #222733;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #222733;
   color: #cbccc6;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #314051;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3b5165;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
   height: 40px !important;
   background: #1f2430;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
   padding-left: 20px;
   padding-right: 20px;
   height: 40px;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
   vertical-align: middle !important;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
   height: 40px !important;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
+body .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
+body .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
   border-color: #1f2430 !important;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
   display: none;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   display: inline-block;
   position: absolute !important;
   top: 0 !important;
   padding-left: 3px;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   padding-top: 5px;
 }
 
-.rstudio-themes-light-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-light-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
-.rstudio-themes-dark-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
+body .windowframe .gwt-TabLayoutPanel > div:last-child,
+body .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
+body .windowframe .gwt-TabLayoutPanel > div:last-child,
+body .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
   top: 38px !important;
 }
 
-.rstudio-themes-light-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
-.rstudio-themes-dark-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
+body .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
+body .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
   height: 40px !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_dialog"],
-.rstudio-themes-light-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-light-menus .dialogTopCenter,
-.rstudio-themes-light-menus .dialogTop,
-.rstudio-themes-light-menus .dialogMiddle,
-.rstudio-themes-light-menus .dataGridHeader,
-.rstudio-themes-dark-menus [id^="rstudio_dialog"],
-.rstudio-themes-dark-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-dark-menus .dialogTopCenter,
-.rstudio-themes-dark-menus .dialogTop,
-.rstudio-themes-dark-menus .dialogMiddle,
-.rstudio-themes-dark-menus .dataGridHeader {
+body [id^="rstudio_dialog"],
+body :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+body .dialogTopCenter,
+body .dialogTop,
+body .dialogMiddle,
+body .dataGridHeader,
+body [id^="rstudio_dialog"],
+body :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+body .dialogTopCenter,
+body .dialogTop,
+body .dialogMiddle,
+body .dataGridHeader {
   background: #1d212b !important;
   color: #cbccc6 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
-.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table,
-.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
+body .dialogContent > table:first-child:last-child :not(button) > table, body .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
+body .dialogContent > table:first-child:last-child :not(button) > table,
+body .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
   background: #1d212b !important;
   color: #cbccc6 !important;
   border-color: #1d212b !important;
 }
 
-.rstudio-themes-light-menus .dialogContent label.gwt-Label,
-.rstudio-themes-light-menus .dialogContent .gwt-RadioButton ~ *,
-.rstudio-themes-dark-menus .dialogContent label.gwt-Label,
-.rstudio-themes-dark-menus .dialogContent .gwt-RadioButton ~ * {
+body .dialogContent label.gwt-Label,
+body .dialogContent .gwt-RadioButton ~ *,
+body .dialogContent label.gwt-Label,
+body .dialogContent .gwt-RadioButton ~ * {
   color: #78a9ff !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
+body .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
+body .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
   color: #aa87e5 !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_dialog"],
-.rstudio-themes-light-menus .dialogTop .dialogTopCenter,
-.rstudio-themes-light-menus .gwt-DialogBox-ModalDialog,
-.rstudio-themes-light-menus .dataGridHeader,
-.rstudio-themes-dark-menus [id^="rstudio_dialog"],
-.rstudio-themes-dark-menus .dialogTop .dialogTopCenter,
-.rstudio-themes-dark-menus .gwt-DialogBox-ModalDialog,
-.rstudio-themes-dark-menus .dataGridHeader {
+body [id^="rstudio_dialog"],
+body .dialogTop .dialogTopCenter,
+body .gwt-DialogBox-ModalDialog,
+body .dataGridHeader,
+body [id^="rstudio_dialog"],
+body .dialogTop .dialogTopCenter,
+body .gwt-DialogBox-ModalDialog,
+body .dataGridHeader {
   /* outer border */
   border-color: #272d3b !important;
 }
 
-.rstudio-themes-light-menus .dialogContent > table div,
-.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
-.rstudio-themes-dark-menus .dialogContent > table div,
-.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
+body .dialogContent > table div,
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
+body .dialogContent > table div,
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
   border-color: #272d3b;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab,
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab {
+body .dialogContent .gwt-TabLayoutPanelTab,
+body .dialogContent .gwt-TabLayoutPanelTab {
   border-color: #272d3b !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab-selected div,
-.rstudio-themes-dark-menus [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab-selected div {
+body [id^="rstudio_label"][aria-selected="true"] div,
+body .dialogContent .gwt-TabLayoutPanelTab-selected div,
+body [id^="rstudio_label"][aria-selected="true"] div,
+body .dialogContent .gwt-TabLayoutPanelTab-selected div {
   background-color: transparent !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-light-menus .dialogContent button table,
-.rstudio-themes-light-menus .dialogContent button:not(:hover) table > tbody > tr > td > div,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-dark-menus .dialogContent button table,
-.rstudio-themes-dark-menus .dialogContent button:not(:hover) table > tbody > tr > td > div {
+body .dialogContent .gwt-Button-DialogAction table,
+body .dialogContent .gwt-Button-DialogAction table td,
+body .dialogContent button table,
+body .dialogContent button:not(:hover) table > tbody > tr > td > div,
+body .dialogContent .gwt-Button-DialogAction table,
+body .dialogContent .gwt-Button-DialogAction table td,
+body .dialogContent button table,
+body .dialogContent button:not(:hover) table > tbody > tr > td > div {
   background: #1d212b !important;
   color: #cbccc6 !important;
   border: none !important;
   box-shadow: none !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
+body .gwt-DialogBox .dialogContent [role="listbox"] > div,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [role="tablist"],
+body .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
+body .gwt-DialogBox .dialogContent [role="listbox"] > div,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [role="tablist"],
+body .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
   /* Dialog options lists and tabs */
   background: #1d212b !important;
   color: #cbccc6 !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
   background-color: #272d3b !important;
   border-color: #272d3b !important;
   color: #cbccc6 !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #cbccc6 !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
   color: #cbccc6 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent button,
-.rstudio-themes-dark-menus .dialogContent button {
+body .dialogContent button,
+body .dialogContent button {
   border-width: 2px !important;
   border-style: solid !important;
   border-color: #272d3b !important;
   border-radius: 3px !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-light-menus .dialogContent button:hover,
-.rstudio-themes-light-menus .dialogContent button:hover table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-light-menus .dialogContent button:hover table > tbody > tr > td > div,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-dark-menus .dialogContent button:hover,
-.rstudio-themes-dark-menus .dialogContent button:hover table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-dark-menus .dialogContent button:hover table > tbody > tr > td > div {
+body .dialogContent .gwt-Button-DialogAction:hover table,
+body .dialogContent .gwt-Button-DialogAction:hover table div,
+body .dialogContent button:hover,
+body .dialogContent button:hover table,
+body .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+body .dialogContent button:hover table > tbody > tr > td > div,
+body .dialogContent .gwt-Button-DialogAction:hover table,
+body .dialogContent .gwt-Button-DialogAction:hover table div,
+body .dialogContent button:hover,
+body .dialogContent button:hover table,
+body .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+body .dialogContent button:hover table > tbody > tr > td > div {
   color: #e4e4e1 !important;
   background: #31394a !important;
   border-color: #272d3b !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input,
-.rstudio-themes-dark-menus .dialogContent input {
+body .dialogContent input,
+body .dialogContent input {
   background: #1d212b !important;
   color: #cbccc6 !important;
   border-color: #272d3b !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input[type="checkbox"],
-.rstudio-themes-dark-menus .dialogContent input[type="checkbox"] {
+body .dialogContent input[type="checkbox"],
+body .dialogContent input[type="checkbox"] {
   background: #272d3b !important;
   color: #cbccc6 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input[type="checkbox"]:checked::before,
-.rstudio-themes-dark-menus .dialogContent input[type="checkbox"]:checked::before {
+body .dialogContent input[type="checkbox"]:checked::before,
+body .dialogContent input[type="checkbox"]:checked::before {
   content: "\2713" !important;
   color: #cbccc6 !important;
   vertical-align: top;
@@ -2981,37 +2981,37 @@ input#rstudio_command_palette_search {
   font-weight: 600;
 }
 
-.rstudio-themes-light-menus .dialogContent select,
-.rstudio-themes-dark-menus .dialogContent select {
+body .dialogContent select,
+body .dialogContent select {
   background: #272d3b !important;
   color: #cbccc6 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-HyperlinkLabel,
-.rstudio-themes-dark-menus .rstudio-HyperlinkLabel {
+body .rstudio-HyperlinkLabel,
+body .rstudio-HyperlinkLabel {
   color: #aa87e5;
 }
 
-.rstudio-themes-light-menus .search,
-.rstudio-themes-dark-menus .search {
+body .search,
+body .search {
   /* code search */
   background-color: #1d212b;
   color: #cbccc6;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center img,
-.rstudio-themes-dark-menus .search .rstheme_center img {
+body .search .rstheme_center img,
+body .search .rstheme_center img {
   display: none;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center::before,
-.rstudio-themes-dark-menus .search .rstheme_center::before {
+body .search .rstheme_center::before,
+body .search .rstheme_center::before {
   content: '\27a0';
   color: #cbccc6;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center > button::before,
-.rstudio-themes-dark-menus .search .rstheme_center > button::before {
+body .search .rstheme_center > button::before,
+body .search .rstheme_center > button::before {
   content: '\2297';
   color: #cbccc6;
   position: relative;
@@ -3019,8 +3019,8 @@ input#rstudio_command_palette_search {
   font-size: 1.25em;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center > button:hover,
-.rstudio-themes-dark-menus .search .rstheme_center > button:hover {
+body .search .rstheme_center > button:hover,
+body .search .rstheme_center > button:hover {
   background: unset !important;
   border: unset !important;
 }

--- a/inst/themes/serendipity-dark.rstheme
+++ b/inst/themes/serendipity-dark.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: Serendipity Dark {rsthemes} */
 /* rs-theme-is-dark: TRUE */
@@ -17,26 +17,26 @@
   color: #cbccc6;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #222733;
   color: #cbccc6;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #222733;
   color: #cbccc6;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #222733;
   color: #cbccc6;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #cbccc6;
 }
 
@@ -271,134 +271,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #1d212b !important;
   color: #cbccc6 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #1d212b !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #1d212b;
   border-color: #222733;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #222733;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #1f2430 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #cbccc6;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #222733 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #cbccc6;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #232936 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #222733 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #cbccc6 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #222733 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #aa87e5;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #222733 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #1d212b !important;
   color: #cbccc6 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #cbccc6 !important;
   background: #374c5f !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #ededed;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #ededed;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #1d212b;
   color: #cbccc6;
   border-color: #ededed;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #ededed;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #1d212b;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #cbccc6;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #1d212b;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #374c5f;
   color: #cbccc6;
 }
@@ -412,15 +412,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #1f2430 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #1f2430 !important;
 }
 
@@ -442,37 +442,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #1f2430 rgba(34, 39, 51, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(34, 39, 51, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #1f2430;
   border-radius: 0px;
   border: 2px solid #222733;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #29303f;
 }
 
@@ -487,26 +487,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-flat .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
+.rstudio-themes-dark-menus .rstudio-themes-dark table.rstudio-themes-background td > div:first-child {
   border-color: #1d212b !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-HDragger {
   border-color: #1d212b;
 }
 
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel-VDragger {
   border-color: #1d212b;
 }
 
-.rstudio-themes-flat > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
+.rstudio-themes-dark-menus > .rstudio-themes-dark .gwt-SplitLayoutPanel td {
   border-color: #222733 !important;
 }
 
 /* window containers */
-.rstudio-themes-flat
+.rstudio-themes-dark-menus
 > .rstudio-themes-dark
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -567,7 +567,7 @@ table.rstheme_tabLayoutCenter .gwt-Label,
   font-style: italic;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
   box-shadow: 0 2px 0 #f06897 inset;
   border-radius: 0 !important;
 }
@@ -2705,202 +2705,275 @@ input#rstudio_command_palette_search {
   border-color: #222733;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #222733;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #222733;
   color: #cbccc6;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #314051;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3b5165;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
   height: 40px !important;
   background: #1f2430;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
   padding-left: 20px;
   padding-right: 20px;
   height: 40px;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
   vertical-align: middle !important;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
   height: 40px !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
+.rstudio-themes-light-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
   border-color: #1f2430 !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
   display: none;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   display: inline-block;
   position: absolute !important;
   top: 0 !important;
   padding-left: 3px;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   padding-top: 5px;
 }
 
-.rstudio-themes-flat .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-flat .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
+.rstudio-themes-light-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
+.rstudio-themes-light-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
+.rstudio-themes-dark-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
   top: 38px !important;
 }
 
-.windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
+.rstudio-themes-light-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
+.rstudio-themes-dark-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
   height: 40px !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_dialog"],
-.rstudio-themes-flat :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-flat .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-flat .dialogTopCenter,
-.rstudio-themes-flat .dialogTop,
-.rstudio-themes-flat .dialogMiddle,
-.rstudio-themes-flat .dataGridHeader {
+.rstudio-themes-light-menus [id^="rstudio_dialog"],
+.rstudio-themes-light-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+.rstudio-themes-light-menus .dialogTopCenter,
+.rstudio-themes-light-menus .dialogTop,
+.rstudio-themes-light-menus .dialogMiddle,
+.rstudio-themes-light-menus .dataGridHeader,
+.rstudio-themes-dark-menus [id^="rstudio_dialog"],
+.rstudio-themes-dark-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+.rstudio-themes-dark-menus .dialogTopCenter,
+.rstudio-themes-dark-menus .dialogTop,
+.rstudio-themes-dark-menus .dialogMiddle,
+.rstudio-themes-dark-menus .dataGridHeader {
   background: #1d212b !important;
   color: #cbccc6 !important;
 }
 
-.rstudio-themes-flat .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-flat .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
+.rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
+.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table,
+.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
   background: #1d212b !important;
   color: #cbccc6 !important;
   border-color: #1d212b !important;
 }
 
-.rstudio-themes-flat .dialogContent label.gwt-Label,
-.rstudio-themes-flat .dialogContent .gwt-RadioButton ~ * {
+.rstudio-themes-light-menus .dialogContent label.gwt-Label,
+.rstudio-themes-light-menus .dialogContent .gwt-RadioButton ~ *,
+.rstudio-themes-dark-menus .dialogContent label.gwt-Label,
+.rstudio-themes-dark-menus .dialogContent .gwt-RadioButton ~ * {
   color: #78a9ff !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
   color: #aa87e5 !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_dialog"],
-.rstudio-themes-flat .dialogTop .dialogTopCenter,
-.rstudio-themes-flat .gwt-DialogBox-ModalDialog,
-.rstudio-themes-flat .dataGridHeader {
+.rstudio-themes-light-menus [id^="rstudio_dialog"],
+.rstudio-themes-light-menus .dialogTop .dialogTopCenter,
+.rstudio-themes-light-menus .gwt-DialogBox-ModalDialog,
+.rstudio-themes-light-menus .dataGridHeader,
+.rstudio-themes-dark-menus [id^="rstudio_dialog"],
+.rstudio-themes-dark-menus .dialogTop .dialogTopCenter,
+.rstudio-themes-dark-menus .gwt-DialogBox-ModalDialog,
+.rstudio-themes-dark-menus .dataGridHeader {
   /* outer border */
   border-color: #272d3b !important;
 }
 
-.rstudio-themes-flat .dialogContent > table div,
-.rstudio-themes-flat .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
+.rstudio-themes-light-menus .dialogContent > table div,
+.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
+.rstudio-themes-dark-menus .dialogContent > table div,
+.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
   border-color: #272d3b;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelTab {
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab,
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab {
   border-color: #272d3b !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelTab-selected div {
+.rstudio-themes-light-menus [id^="rstudio_label"][aria-selected="true"] div,
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab-selected div,
+.rstudio-themes-dark-menus [id^="rstudio_label"][aria-selected="true"] div,
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab-selected div {
   background-color: transparent !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-flat .dialogContent button table,
-.rstudio-themes-flat .dialogContent button:not(:hover) table > tbody > tr > td > div {
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table td,
+.rstudio-themes-light-menus .dialogContent button table,
+.rstudio-themes-light-menus .dialogContent button:not(:hover) table > tbody > tr > td > div,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table td,
+.rstudio-themes-dark-menus .dialogContent button table,
+.rstudio-themes-dark-menus .dialogContent button:not(:hover) table > tbody > tr > td > div {
   background: #1d212b !important;
   color: #cbccc6 !important;
   border: none !important;
   box-shadow: none !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
   /* Dialog options lists and tabs */
   background: #1d212b !important;
   color: #cbccc6 !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
   background-color: #272d3b !important;
   border-color: #272d3b !important;
   color: #cbccc6 !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #cbccc6 !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
   color: #cbccc6 !important;
 }
 
-.rstudio-themes-flat .dialogContent button {
+.rstudio-themes-light-menus .dialogContent button,
+.rstudio-themes-dark-menus .dialogContent button {
   border-width: 2px !important;
   border-style: solid !important;
   border-color: #272d3b !important;
   border-radius: 3px !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-flat .dialogContent button:hover,
-.rstudio-themes-flat .dialogContent button:hover table,
-.rstudio-themes-flat .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-flat .dialogContent button:hover table > tbody > tr > td > div {
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table div,
+.rstudio-themes-light-menus .dialogContent button:hover,
+.rstudio-themes-light-menus .dialogContent button:hover table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+.rstudio-themes-light-menus .dialogContent button:hover table > tbody > tr > td > div,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table div,
+.rstudio-themes-dark-menus .dialogContent button:hover,
+.rstudio-themes-dark-menus .dialogContent button:hover table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+.rstudio-themes-dark-menus .dialogContent button:hover table > tbody > tr > td > div {
   color: #e4e4e1 !important;
   background: #31394a !important;
   border-color: #272d3b !important;
 }
 
-.rstudio-themes-flat .dialogContent input {
+.rstudio-themes-light-menus .dialogContent input,
+.rstudio-themes-dark-menus .dialogContent input {
   background: #1d212b !important;
   color: #cbccc6 !important;
   border-color: #272d3b !important;
 }
 
-.rstudio-themes-flat .dialogContent input[type="checkbox"] {
+.rstudio-themes-light-menus .dialogContent input[type="checkbox"],
+.rstudio-themes-dark-menus .dialogContent input[type="checkbox"] {
   background: #272d3b !important;
   color: #cbccc6 !important;
 }
 
-.rstudio-themes-flat .dialogContent input[type="checkbox"]:checked::before {
+.rstudio-themes-light-menus .dialogContent input[type="checkbox"]:checked::before,
+.rstudio-themes-dark-menus .dialogContent input[type="checkbox"]:checked::before {
   content: "\2713" !important;
   color: #cbccc6 !important;
   vertical-align: top;
@@ -2908,31 +2981,37 @@ input#rstudio_command_palette_search {
   font-weight: 600;
 }
 
-.rstudio-themes-flat .dialogContent select {
+.rstudio-themes-light-menus .dialogContent select,
+.rstudio-themes-dark-menus .dialogContent select {
   background: #272d3b !important;
   color: #cbccc6 !important;
 }
 
-.rstudio-themes-flat .rstudio-HyperlinkLabel {
+.rstudio-themes-light-menus .rstudio-HyperlinkLabel,
+.rstudio-themes-dark-menus .rstudio-HyperlinkLabel {
   color: #aa87e5;
 }
 
-.rstudio-themes-flat .search {
+.rstudio-themes-light-menus .search,
+.rstudio-themes-dark-menus .search {
   /* code search */
   background-color: #1d212b;
   color: #cbccc6;
 }
 
-.rstudio-themes-flat .search .rstheme_center img {
+.rstudio-themes-light-menus .search .rstheme_center img,
+.rstudio-themes-dark-menus .search .rstheme_center img {
   display: none;
 }
 
-.rstudio-themes-flat .search .rstheme_center::before {
+.rstudio-themes-light-menus .search .rstheme_center::before,
+.rstudio-themes-dark-menus .search .rstheme_center::before {
   content: '\27a0';
   color: #cbccc6;
 }
 
-.rstudio-themes-flat .search .rstheme_center > button::before {
+.rstudio-themes-light-menus .search .rstheme_center > button::before,
+.rstudio-themes-dark-menus .search .rstheme_center > button::before {
   content: '\2297';
   color: #cbccc6;
   position: relative;
@@ -2940,7 +3019,8 @@ input#rstudio_command_palette_search {
   font-size: 1.25em;
 }
 
-.rstudio-themes-flat .search .rstheme_center > button:hover {
+.rstudio-themes-light-menus .search .rstheme_center > button:hover,
+.rstudio-themes-dark-menus .search .rstheme_center > button:hover {
   background: unset !important;
   border: unset !important;
 }

--- a/inst/themes/serendipity-light.rstheme
+++ b/inst/themes/serendipity-light.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: Serendipity Light {rsthemes} */
 /* rs-theme-is-dark: FALSE */
@@ -17,35 +17,35 @@
   color: #576067;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-light-menus.ace_editor_theme {
   background-color: #fafafa;
   color: #576067;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #fafafa;
   color: #576067;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-light-menus .ace_editor_theme {
   background-color: #fafafa !important;
   color: #576067 !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table {
+.rstudio-themes-light-menus .ace_editor_theme table {
   background-color: #fafafa !important;
 }
 
-.rstudio-themes-flat .ace_editor_theme table thead > tr > th {
+.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
   background-color: #fafafa !important;
 }
 
-.rstudio-themes-flat.ace_editor_theme a {
+.rstudio-themes-light-menus.ace_editor_theme a {
   color: #576067 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-light-menus .gwt-Label {
   color: #576067;
 }
 
@@ -310,148 +310,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   background: #f4f4f4 !important;
   color: #576067 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
   background: #f4f4f4 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #f4f4f4;
   border-color: #fafafa;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
   border-color: #fafafa;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #f0f0f0 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #898f93;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-default .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #fafafa !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #232834;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: whitesmoke !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper {
   background: #fafafa !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
   color: #576067 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .search, .rstudio-themes-flat.rstudio-themes-default-menus .search {
+.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
   /* search */
   background: #fafafa !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #a173ff;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
   background: #fafafa !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-light-menus .popupMiddleCenter,
+.rstudio-themes-light-menus .menuPopupMiddleCenter,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter {
   background: #fafafa !important;
   color: #576067 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #576067 !important;
   background: #d8eaf5 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-light-menus .themedPopupPanel {
   border: solid 1px #ededed;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #ededed;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-light-menus .popupContent {
   background: #fafafa;
   color: #576067;
   border-color: #ededed;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #ededed;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
   background: #fafafa;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
   background: #576067;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #fafafa;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #d8eaf5;
   color: #576067;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-default {
+.rstudio-themes-light-menus .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #f0f0f0 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #f0f0f0 !important;
 }
 
@@ -473,36 +473,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-light-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-scrollbars {
+.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #ededed rgba(250, 250, 250, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(250, 250, 250, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #ededed;
   border-radius: 0px;
   border: 2px solid #fafafa;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #e1e1e1;
 }
 
@@ -517,26 +517,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-flat table.rstudio-themes-background td > div:first-child {
+.rstudio-themes-light-menus table.rstudio-themes-background td > div:first-child {
   border-color: #f4f4f4 !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-flat > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
+.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
   border-color: #f4f4f4;
 }
 
-.rstudio-themes-flat > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   border-color: #f4f4f4;
 }
 
-.rstudio-themes-flat > .rstudio-themes-default .gwt-SplitLayoutPanel td {
+.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel td {
   border-color: #fafafa !important;
 }
 
 /* window containers */
-.rstudio-themes-flat
+.rstudio-themes-light-menus
 > .rstudio-themes-default
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -596,7 +596,7 @@ table.rstheme_tabLayoutCenter .gwt-Label,
   font-style: italic;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
   box-shadow: 0 2px 0 #ED5A5A inset;
   border-radius: 0 !important;
 }
@@ -2734,202 +2734,275 @@ input#rstudio_command_palette_search {
   border-color: #fafafa;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #fafafa;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #fafafa;
   color: #576067;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #c1e4fa;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #87cefa;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
   height: 40px !important;
   background: #f0f0f0;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
   padding-left: 20px;
   padding-right: 20px;
   height: 40px;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
   vertical-align: middle !important;
 }
 
-.rstudio-themes-flat > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
+.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
+.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
   height: 40px !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
+.rstudio-themes-light-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
   border-color: #f0f0f0 !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
   display: none;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   display: inline-block;
   position: absolute !important;
   top: 0 !important;
   padding-left: 3px;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   padding-top: 5px;
 }
 
-.rstudio-themes-flat .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-flat .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
+.rstudio-themes-light-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
+.rstudio-themes-light-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
+.rstudio-themes-dark-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
+.rstudio-themes-dark-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
   top: 38px !important;
 }
 
-.windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
+.rstudio-themes-light-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
+.rstudio-themes-dark-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
   height: 40px !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_dialog"],
-.rstudio-themes-flat :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-flat .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-flat .dialogTopCenter,
-.rstudio-themes-flat .dialogTop,
-.rstudio-themes-flat .dialogMiddle,
-.rstudio-themes-flat .dataGridHeader {
+.rstudio-themes-light-menus [id^="rstudio_dialog"],
+.rstudio-themes-light-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+.rstudio-themes-light-menus .dialogTopCenter,
+.rstudio-themes-light-menus .dialogTop,
+.rstudio-themes-light-menus .dialogMiddle,
+.rstudio-themes-light-menus .dataGridHeader,
+.rstudio-themes-dark-menus [id^="rstudio_dialog"],
+.rstudio-themes-dark-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+.rstudio-themes-dark-menus .dialogTopCenter,
+.rstudio-themes-dark-menus .dialogTop,
+.rstudio-themes-dark-menus .dialogMiddle,
+.rstudio-themes-dark-menus .dataGridHeader {
   background: #f4f4f4 !important;
   color: #576067 !important;
 }
 
-.rstudio-themes-flat .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-flat .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
+.rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
+.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table,
+.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
   background: #f4f4f4 !important;
   color: #576067 !important;
   border-color: #f4f4f4 !important;
 }
 
-.rstudio-themes-flat .dialogContent label.gwt-Label,
-.rstudio-themes-flat .dialogContent .gwt-RadioButton ~ * {
+.rstudio-themes-light-menus .dialogContent label.gwt-Label,
+.rstudio-themes-light-menus .dialogContent .gwt-RadioButton ~ *,
+.rstudio-themes-dark-menus .dialogContent label.gwt-Label,
+.rstudio-themes-dark-menus .dialogContent .gwt-RadioButton ~ * {
   color: #4589ff !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
   color: #a173ff !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_dialog"],
-.rstudio-themes-flat .dialogTop .dialogTopCenter,
-.rstudio-themes-flat .gwt-DialogBox-ModalDialog,
-.rstudio-themes-flat .dataGridHeader {
+.rstudio-themes-light-menus [id^="rstudio_dialog"],
+.rstudio-themes-light-menus .dialogTop .dialogTopCenter,
+.rstudio-themes-light-menus .gwt-DialogBox-ModalDialog,
+.rstudio-themes-light-menus .dataGridHeader,
+.rstudio-themes-dark-menus [id^="rstudio_dialog"],
+.rstudio-themes-dark-menus .dialogTop .dialogTopCenter,
+.rstudio-themes-dark-menus .gwt-DialogBox-ModalDialog,
+.rstudio-themes-dark-menus .dataGridHeader {
   /* outer border */
   border-color: #e7e7e7 !important;
 }
 
-.rstudio-themes-flat .dialogContent > table div,
-.rstudio-themes-flat .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
+.rstudio-themes-light-menus .dialogContent > table div,
+.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
+.rstudio-themes-dark-menus .dialogContent > table div,
+.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
   border-color: #e7e7e7;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelTab {
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab,
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab {
   border-color: #e7e7e7 !important;
 }
 
-.rstudio-themes-flat [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-flat .dialogContent .gwt-TabLayoutPanelTab-selected div {
+.rstudio-themes-light-menus [id^="rstudio_label"][aria-selected="true"] div,
+.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab-selected div,
+.rstudio-themes-dark-menus [id^="rstudio_label"][aria-selected="true"] div,
+.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab-selected div {
   background-color: transparent !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-flat .dialogContent button table,
-.rstudio-themes-flat .dialogContent button:not(:hover) table > tbody > tr > td > div {
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table td,
+.rstudio-themes-light-menus .dialogContent button table,
+.rstudio-themes-light-menus .dialogContent button:not(:hover) table > tbody > tr > td > div,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table td,
+.rstudio-themes-dark-menus .dialogContent button table,
+.rstudio-themes-dark-menus .dialogContent button:not(:hover) table > tbody > tr > td > div {
   background: #f4f4f4 !important;
   color: #576067 !important;
   border: none !important;
   box-shadow: none !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
   /* Dialog options lists and tabs */
   background: #f4f4f4 !important;
   color: #576067 !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
   background-color: #e7e7e7 !important;
   border-color: #e7e7e7 !important;
   color: #576067 !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #576067 !important;
 }
 
-.rstudio-themes-flat .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
+.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
+.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
   color: #576067 !important;
 }
 
-.rstudio-themes-flat .dialogContent button {
+.rstudio-themes-light-menus .dialogContent button,
+.rstudio-themes-dark-menus .dialogContent button {
   border-width: 2px !important;
   border-style: solid !important;
   border-color: #e7e7e7 !important;
   border-radius: 3px !important;
 }
 
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-flat .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-flat .dialogContent button:hover,
-.rstudio-themes-flat .dialogContent button:hover table,
-.rstudio-themes-flat .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-flat .dialogContent button:hover table > tbody > tr > td > div {
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table div,
+.rstudio-themes-light-menus .dialogContent button:hover,
+.rstudio-themes-light-menus .dialogContent button:hover table,
+.rstudio-themes-light-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+.rstudio-themes-light-menus .dialogContent button:hover table > tbody > tr > td > div,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table div,
+.rstudio-themes-dark-menus .dialogContent button:hover,
+.rstudio-themes-dark-menus .dialogContent button:hover table,
+.rstudio-themes-dark-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+.rstudio-themes-dark-menus .dialogContent button:hover table > tbody > tr > td > div {
   color: #6e7a83 !important;
   background: white !important;
   border-color: #e7e7e7 !important;
 }
 
-.rstudio-themes-flat .dialogContent input {
+.rstudio-themes-light-menus .dialogContent input,
+.rstudio-themes-dark-menus .dialogContent input {
   background: #f4f4f4 !important;
   color: #576067 !important;
   border-color: #e7e7e7 !important;
 }
 
-.rstudio-themes-flat .dialogContent input[type="checkbox"] {
+.rstudio-themes-light-menus .dialogContent input[type="checkbox"],
+.rstudio-themes-dark-menus .dialogContent input[type="checkbox"] {
   background: white !important;
   color: #576067 !important;
 }
 
-.rstudio-themes-flat .dialogContent input[type="checkbox"]:checked::before {
+.rstudio-themes-light-menus .dialogContent input[type="checkbox"]:checked::before,
+.rstudio-themes-dark-menus .dialogContent input[type="checkbox"]:checked::before {
   content: "\2713" !important;
   color: #576067 !important;
   vertical-align: top;
@@ -2937,31 +3010,37 @@ input#rstudio_command_palette_search {
   font-weight: 600;
 }
 
-.rstudio-themes-flat .dialogContent select {
+.rstudio-themes-light-menus .dialogContent select,
+.rstudio-themes-dark-menus .dialogContent select {
   background: white !important;
   color: #576067 !important;
 }
 
-.rstudio-themes-flat .rstudio-HyperlinkLabel {
+.rstudio-themes-light-menus .rstudio-HyperlinkLabel,
+.rstudio-themes-dark-menus .rstudio-HyperlinkLabel {
   color: #a173ff;
 }
 
-.rstudio-themes-flat .search {
+.rstudio-themes-light-menus .search,
+.rstudio-themes-dark-menus .search {
   /* code search */
   background-color: #f4f4f4;
   color: #576067;
 }
 
-.rstudio-themes-flat .search .rstheme_center img {
+.rstudio-themes-light-menus .search .rstheme_center img,
+.rstudio-themes-dark-menus .search .rstheme_center img {
   display: none;
 }
 
-.rstudio-themes-flat .search .rstheme_center::before {
+.rstudio-themes-light-menus .search .rstheme_center::before,
+.rstudio-themes-dark-menus .search .rstheme_center::before {
   content: '\27a0';
   color: #576067;
 }
 
-.rstudio-themes-flat .search .rstheme_center > button::before {
+.rstudio-themes-light-menus .search .rstheme_center > button::before,
+.rstudio-themes-dark-menus .search .rstheme_center > button::before {
   content: '\2297';
   color: #576067;
   position: relative;
@@ -2969,7 +3048,8 @@ input#rstudio_command_palette_search {
   font-size: 1.25em;
 }
 
-.rstudio-themes-flat .search .rstheme_center > button:hover {
+.rstudio-themes-light-menus .search .rstheme_center > button:hover,
+.rstudio-themes-dark-menus .search .rstheme_center > button:hover {
   background: unset !important;
   border: unset !important;
 }

--- a/inst/themes/serendipity-light.rstheme
+++ b/inst/themes/serendipity-light.rstheme
@@ -17,35 +17,35 @@
   color: #576067;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #fafafa;
   color: #576067;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #fafafa;
   color: #576067;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #fafafa !important;
   color: #576067 !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table {
+body .ace_editor_theme table {
   background-color: #fafafa !important;
 }
 
-.rstudio-themes-light-menus .ace_editor_theme table thead > tr > th {
+body .ace_editor_theme table thead > tr > th {
   background-color: #fafafa !important;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme a {
+body.ace_editor_theme a {
   color: #576067 !important;
   font-weight: bold;
 }
 
-.rstudio-themes-light-menus .gwt-Label {
+body .gwt-Label {
   color: #576067;
 }
 
@@ -310,148 +310,148 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   background: #f4f4f4 !important;
   color: #576067 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-background {
+body .rstudio-themes-default .rstudio-themes-background {
   background: #f4f4f4 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-light-menus .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
+body .rstudio-themes-default [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+body .rstudio-themes-default header + [role="navigation"] > table > tbody > tr > td {
   background: #f4f4f4;
   border-color: #fafafa;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .rstudio-themes-border {
+body .rstudio-themes-default .rstudio-themes-border {
   border-color: #fafafa;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #f0f0f0 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #898f93;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-light-menus .rstudio-themes-default .rstheme_center,
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-default .rstheme_center,
+body .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #fafafa !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #232834;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-default .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: whitesmoke !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #fafafa !important;
 }
 
-.rstudio-themes-light-menus .rstheme_toolbarWrapper button, .rstudio-themes-light-menus .rstheme_toolbarWrapper a, .rstudio-themes-light-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #576067 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-light-menus .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-light-menus .search, .rstudio-themes-light-menus.rstudio-themes-default-menus .search {
+body .search, body.rstudio-themes-default-menus .search {
   /* search */
   background: #fafafa !important;
 }
 
-.rstudio-themes-light-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #a173ff;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-light-menus .dataGridHeader {
+.rstheme_secondaryToolbar, body .dataGridHeader {
   background: #fafafa !important;
 }
 
 /* menu background */
-.rstudio-themes-light-menus .popupMiddleCenter,
-.rstudio-themes-light-menus .menuPopupMiddleCenter,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #fafafa !important;
   color: #576067 !important;
 }
 
-.rstudio-themes-light-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-light-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #576067 !important;
   background: #d8eaf5 !important;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #ededed;
 }
 
-.rstudio-themes-light-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #ededed;
 }
 
-.rstudio-themes-light-menus .popupContent {
+body .popupContent {
   background: #fafafa;
   color: #576067;
   border-color: #ededed;
 }
 
-.rstudio-themes-light-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-light-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #ededed;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #fafafa;
   padding: 2px;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #576067;
   border: 0;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #fafafa;
 }
 
-.rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-light-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #d8eaf5;
   color: #576067;
 }
 
 /* hacky toolbars section */
-.rstudio-themes-light-menus .rstudio-themes-default {
+body .rstudio-themes-default {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #f0f0f0 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-default .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #f0f0f0 !important;
 }
 
@@ -473,36 +473,36 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-light-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-light-menus, .rstudio-themes-light-menus .rstudio-themes-scrollbars {
+body, body .rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #ededed rgba(250, 250, 250, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-light-menus ::-webkit-scrollbar, .rstudio-themes-light-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-track, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(250, 250, 250, 0.5);
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #ededed;
   border-radius: 0px;
   border: 2px solid #fafafa;
 }
 
-.rstudio-themes-light-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-light-menus .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #e1e1e1;
 }
 
@@ -517,26 +517,26 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* borders on toolbar under editor */
-.rstudio-themes-light-menus table.rstudio-themes-background td > div:first-child {
+body table.rstudio-themes-background td > div:first-child {
   border-color: #f4f4f4 !important;
 }
 
 /* Borrowed from https://github.com/anthonynorth/rscodeio */
 /* splitters */
-.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
+body > .rstudio-themes-default .gwt-SplitLayoutPanel-HDragger {
   border-color: #f4f4f4;
 }
 
-.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
+body > .rstudio-themes-default .gwt-SplitLayoutPanel-VDragger {
   border-color: #f4f4f4;
 }
 
-.rstudio-themes-light-menus > .rstudio-themes-default .gwt-SplitLayoutPanel td {
+body > .rstudio-themes-default .gwt-SplitLayoutPanel td {
   border-color: #fafafa !important;
 }
 
 /* window containers */
-.rstudio-themes-light-menus
+body
 > .rstudio-themes-default
 :-webkit-any(.windowframe, .rstheme_minimizedWindowObject)
 > div:last-child {
@@ -596,7 +596,7 @@ table.rstheme_tabLayoutCenter .gwt-Label,
   font-style: italic;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
+body .gwt-TabLayoutPanelTab-selected .gwt-TabLayoutPanelTabInner .rstheme_tabLayoutCenter {
   box-shadow: 0 2px 0 #ED5A5A inset;
   border-radius: 0 !important;
 }
@@ -2734,275 +2734,275 @@ input#rstudio_command_palette_search {
   border-color: #fafafa;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #fafafa;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #fafafa;
   color: #576067;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #c1e4fa;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #87cefa;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel > div[aria-hidden="true"] + div {
   height: 40px !important;
   background: #f0f0f0;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter {
   padding-left: 20px;
   padding-right: 20px;
   height: 40px;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs .rstheme_tabLayoutCenter td {
   vertical-align: middle !important;
 }
 
-.rstudio-themes-light-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
-.rstudio-themes-dark-menus > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty,
+body > :not(.gwt-DialogBox-ModalDialog) .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs > div:empty {
   height: 40px !important;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
+body .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs,
+body .gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs {
   border-color: #f0f0f0 !important;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter tbody > tr > td:last-child > img {
   display: none;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   display: inline-block;
   position: absolute !important;
   top: 0 !important;
   padding-left: 3px;
 }
 
-.rstudio-themes-light-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
+body .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img,
+body .gwt-TabLayoutPanelTabs [id^="rstudio_workbench_"] .gwt-TabLayoutPanelTabInner table.rstheme_tabLayoutCenter:hover tbody > tr > td:last-child > img {
   padding-top: 5px;
 }
 
-.rstudio-themes-light-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-light-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
-.rstudio-themes-dark-menus .windowframe .gwt-TabLayoutPanel > div:last-child,
-.rstudio-themes-dark-menus .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
+body .windowframe .gwt-TabLayoutPanel > div:last-child,
+body .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child,
+body .windowframe .gwt-TabLayoutPanel > div:last-child,
+body .gwt-TabLayoutPanel.rstudio_source_panel > div:last-child {
   top: 38px !important;
 }
 
-.rstudio-themes-light-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
-.rstudio-themes-dark-menus .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
+body .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div,
+body .windowframe > div:last-child > div > div > div[aria-hidden="true"] + div + div {
   height: 40px !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_dialog"],
-.rstudio-themes-light-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-light-menus .dialogTopCenter,
-.rstudio-themes-light-menus .dialogTop,
-.rstudio-themes-light-menus .dialogMiddle,
-.rstudio-themes-light-menus .dataGridHeader,
-.rstudio-themes-dark-menus [id^="rstudio_dialog"],
-.rstudio-themes-dark-menus :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
-.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
-.rstudio-themes-dark-menus .dialogTopCenter,
-.rstudio-themes-dark-menus .dialogTop,
-.rstudio-themes-dark-menus .dialogMiddle,
-.rstudio-themes-dark-menus .dataGridHeader {
+body [id^="rstudio_dialog"],
+body :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+body .dialogTopCenter,
+body .dialogTop,
+body .dialogMiddle,
+body .dataGridHeader,
+body [id^="rstudio_dialog"],
+body :not(.gwt-MenuItem-selected):not(.gwt-MenuItem) > [id^="rstudio_label"],
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] :not(button) > table > tbody > td,
+body .dialogTopCenter,
+body .dialogTop,
+body .dialogMiddle,
+body .dataGridHeader {
   background: #f4f4f4 !important;
   color: #576067 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table, .rstudio-themes-light-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
-.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table,
-.rstudio-themes-dark-menus .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
+body .dialogContent > table:first-child:last-child :not(button) > table, body .dialogContent > table:first-child:last-child :not(button) > table > tbody > td,
+body .dialogContent > table:first-child:last-child :not(button) > table,
+body .dialogContent > table:first-child:last-child :not(button) > table > tbody > td {
   background: #f4f4f4 !important;
   color: #576067 !important;
   border-color: #f4f4f4 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent label.gwt-Label,
-.rstudio-themes-light-menus .dialogContent .gwt-RadioButton ~ *,
-.rstudio-themes-dark-menus .dialogContent label.gwt-Label,
-.rstudio-themes-dark-menus .dialogContent .gwt-RadioButton ~ * {
+body .dialogContent label.gwt-Label,
+body .dialogContent .gwt-RadioButton ~ *,
+body .dialogContent label.gwt-Label,
+body .dialogContent .gwt-RadioButton ~ * {
   color: #4589ff !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
+body .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label),
+body .dialogContent .gwt-TabLayoutPanelContent .gwt-Label:not(label) {
   color: #a173ff !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_dialog"],
-.rstudio-themes-light-menus .dialogTop .dialogTopCenter,
-.rstudio-themes-light-menus .gwt-DialogBox-ModalDialog,
-.rstudio-themes-light-menus .dataGridHeader,
-.rstudio-themes-dark-menus [id^="rstudio_dialog"],
-.rstudio-themes-dark-menus .dialogTop .dialogTopCenter,
-.rstudio-themes-dark-menus .gwt-DialogBox-ModalDialog,
-.rstudio-themes-dark-menus .dataGridHeader {
+body [id^="rstudio_dialog"],
+body .dialogTop .dialogTopCenter,
+body .gwt-DialogBox-ModalDialog,
+body .dataGridHeader,
+body [id^="rstudio_dialog"],
+body .dialogTop .dialogTopCenter,
+body .gwt-DialogBox-ModalDialog,
+body .dataGridHeader {
   /* outer border */
   border-color: #e7e7e7 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent > table div,
-.rstudio-themes-light-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
-.rstudio-themes-dark-menus .dialogContent > table div,
-.rstudio-themes-dark-menus .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
+body .dialogContent > table div,
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td,
+body .dialogContent > table div,
+body .dialogContent [id^="rstudio_label_"][id$="_panel"] table tbody td {
   border-color: #e7e7e7;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab,
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab {
+body .dialogContent .gwt-TabLayoutPanelTab,
+body .dialogContent .gwt-TabLayoutPanelTab {
   border-color: #e7e7e7 !important;
 }
 
-.rstudio-themes-light-menus [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-light-menus .dialogContent .gwt-TabLayoutPanelTab-selected div,
-.rstudio-themes-dark-menus [id^="rstudio_label"][aria-selected="true"] div,
-.rstudio-themes-dark-menus .dialogContent .gwt-TabLayoutPanelTab-selected div {
+body [id^="rstudio_label"][aria-selected="true"] div,
+body .dialogContent .gwt-TabLayoutPanelTab-selected div,
+body [id^="rstudio_label"][aria-selected="true"] div,
+body .dialogContent .gwt-TabLayoutPanelTab-selected div {
   background-color: transparent !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-light-menus .dialogContent button table,
-.rstudio-themes-light-menus .dialogContent button:not(:hover) table > tbody > tr > td > div,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction table td,
-.rstudio-themes-dark-menus .dialogContent button table,
-.rstudio-themes-dark-menus .dialogContent button:not(:hover) table > tbody > tr > td > div {
+body .dialogContent .gwt-Button-DialogAction table,
+body .dialogContent .gwt-Button-DialogAction table td,
+body .dialogContent button table,
+body .dialogContent button:not(:hover) table > tbody > tr > td > div,
+body .dialogContent .gwt-Button-DialogAction table,
+body .dialogContent .gwt-Button-DialogAction table td,
+body .dialogContent button table,
+body .dialogContent button:not(:hover) table > tbody > tr > td > div {
   background: #f4f4f4 !important;
   color: #576067 !important;
   border: none !important;
   box-shadow: none !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] > div,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
+body .gwt-DialogBox .dialogContent [role="listbox"] > div,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [role="tablist"],
+body .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab,
+body .gwt-DialogBox .dialogContent [role="listbox"] > div,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [role="tablist"],
+body .gwt-DialogBox .dialogContent [role="tablist"] [role="tab"]:not([aria-selected="true"]) .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab {
   /* Dialog options lists and tabs */
   background: #f4f4f4 !important;
   color: #576067 !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected,
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [role="listbox"] [role="option"][aria-selected="true"] .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"],
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected {
   background-color: #e7e7e7 !important;
   border-color: #e7e7e7 !important;
   color: #576067 !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label,
+body .gwt-DialogBox .dialogContent .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #576067 !important;
 }
 
-.rstudio-themes-light-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
-.rstudio-themes-dark-menus .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label,
+body .gwt-DialogBox .dialogContent [id^="rstudio_label"][aria-selected="true"] td .gwt-Label {
   color: #576067 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent button,
-.rstudio-themes-dark-menus .dialogContent button {
+body .dialogContent button,
+body .dialogContent button {
   border-width: 2px !important;
   border-style: solid !important;
   border-color: #e7e7e7 !important;
   border-radius: 3px !important;
 }
 
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-light-menus .dialogContent button:hover,
-.rstudio-themes-light-menus .dialogContent button:hover table,
-.rstudio-themes-light-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-light-menus .dialogContent button:hover table > tbody > tr > td > div,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button-DialogAction:hover table div,
-.rstudio-themes-dark-menus .dialogContent button:hover,
-.rstudio-themes-dark-menus .dialogContent button:hover table,
-.rstudio-themes-dark-menus .dialogContent .gwt-Button:hover > table > tbody > tr > td,
-.rstudio-themes-dark-menus .dialogContent button:hover table > tbody > tr > td > div {
+body .dialogContent .gwt-Button-DialogAction:hover table,
+body .dialogContent .gwt-Button-DialogAction:hover table div,
+body .dialogContent button:hover,
+body .dialogContent button:hover table,
+body .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+body .dialogContent button:hover table > tbody > tr > td > div,
+body .dialogContent .gwt-Button-DialogAction:hover table,
+body .dialogContent .gwt-Button-DialogAction:hover table div,
+body .dialogContent button:hover,
+body .dialogContent button:hover table,
+body .dialogContent .gwt-Button:hover > table > tbody > tr > td,
+body .dialogContent button:hover table > tbody > tr > td > div {
   color: #6e7a83 !important;
   background: white !important;
   border-color: #e7e7e7 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input,
-.rstudio-themes-dark-menus .dialogContent input {
+body .dialogContent input,
+body .dialogContent input {
   background: #f4f4f4 !important;
   color: #576067 !important;
   border-color: #e7e7e7 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input[type="checkbox"],
-.rstudio-themes-dark-menus .dialogContent input[type="checkbox"] {
+body .dialogContent input[type="checkbox"],
+body .dialogContent input[type="checkbox"] {
   background: white !important;
   color: #576067 !important;
 }
 
-.rstudio-themes-light-menus .dialogContent input[type="checkbox"]:checked::before,
-.rstudio-themes-dark-menus .dialogContent input[type="checkbox"]:checked::before {
+body .dialogContent input[type="checkbox"]:checked::before,
+body .dialogContent input[type="checkbox"]:checked::before {
   content: "\2713" !important;
   color: #576067 !important;
   vertical-align: top;
@@ -3010,37 +3010,37 @@ input#rstudio_command_palette_search {
   font-weight: 600;
 }
 
-.rstudio-themes-light-menus .dialogContent select,
-.rstudio-themes-dark-menus .dialogContent select {
+body .dialogContent select,
+body .dialogContent select {
   background: white !important;
   color: #576067 !important;
 }
 
-.rstudio-themes-light-menus .rstudio-HyperlinkLabel,
-.rstudio-themes-dark-menus .rstudio-HyperlinkLabel {
+body .rstudio-HyperlinkLabel,
+body .rstudio-HyperlinkLabel {
   color: #a173ff;
 }
 
-.rstudio-themes-light-menus .search,
-.rstudio-themes-dark-menus .search {
+body .search,
+body .search {
   /* code search */
   background-color: #f4f4f4;
   color: #576067;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center img,
-.rstudio-themes-dark-menus .search .rstheme_center img {
+body .search .rstheme_center img,
+body .search .rstheme_center img {
   display: none;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center::before,
-.rstudio-themes-dark-menus .search .rstheme_center::before {
+body .search .rstheme_center::before,
+body .search .rstheme_center::before {
   content: '\27a0';
   color: #576067;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center > button::before,
-.rstudio-themes-dark-menus .search .rstheme_center > button::before {
+body .search .rstheme_center > button::before,
+body .search .rstheme_center > button::before {
   content: '\2297';
   color: #576067;
   position: relative;
@@ -3048,8 +3048,8 @@ input#rstudio_command_palette_search {
   font-size: 1.25em;
 }
 
-.rstudio-themes-light-menus .search .rstheme_center > button:hover,
-.rstudio-themes-dark-menus .search .rstheme_center > button:hover {
+body .search .rstheme_center > button:hover,
+body .search .rstheme_center > button:hover {
   background: unset !important;
   border: unset !important;
 }

--- a/inst/themes/solarized-dark.rstheme
+++ b/inst/themes/solarized-dark.rstheme
@@ -22,26 +22,26 @@
   color: #839496;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #002b36;
   color: #839496;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #002b36;
   color: #839496;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #002b36;
   color: #839496;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #839496;
 }
 
@@ -298,112 +298,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #073642 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #93a1a1;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #586e75 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #fdf6e3;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #073642 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #586e75 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #eee8d5 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #586e75 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #cb4b16;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #586e75 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #002b36 !important;
   color: #839496 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #839496 !important;
   background: #586e75 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #657b83;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #657b83;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #002b36;
   color: #839496;
   border-color: #657b83;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #657b83;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #002b36;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #839496;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #002b36;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #586e75;
   color: #839496;
 }
@@ -417,15 +417,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #073642 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #073642 !important;
 }
 
@@ -447,37 +447,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #073642 rgba(0, 43, 54, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(0, 43, 54, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #073642;
   border-radius: 0px;
   border: 2px solid #002b36;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #094959;
 }
 
@@ -2624,49 +2624,49 @@ input#rstudio_command_palette_search {
   border-color: #002b36;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #002b36;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #002b36;
   color: #839496;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #003f50;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #005469;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/solarized-dark.rstheme
+++ b/inst/themes/solarized-dark.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: Solarized Dark {rsthemes} */
 /* rs-theme-is-dark: TRUE */
@@ -22,26 +22,26 @@
   color: #839496;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #002b36;
   color: #839496;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #002b36;
   color: #839496;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #002b36;
   color: #839496;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #839496;
 }
 
@@ -276,134 +276,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #073642 !important;
   color: #839496 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #073642 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #073642;
   border-color: #002b36;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #002b36;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #073642 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #93a1a1;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #586e75 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #fdf6e3;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #073642 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #586e75 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #eee8d5 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #586e75 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #cb4b16;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #586e75 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #002b36 !important;
   color: #839496 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #839496 !important;
   background: #586e75 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #657b83;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #657b83;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #002b36;
   color: #839496;
   border-color: #657b83;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #657b83;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #002b36;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #839496;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #002b36;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #586e75;
   color: #839496;
 }
@@ -417,15 +417,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #073642 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #073642 !important;
 }
 
@@ -447,37 +447,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #073642 rgba(0, 43, 54, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(0, 43, 54, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #073642;
   border-radius: 0px;
   border: 2px solid #002b36;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #094959;
 }
 
@@ -2624,35 +2624,49 @@ input#rstudio_command_palette_search {
   border-color: #002b36;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #002b36;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #002b36;
   color: #839496;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #003f50;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #005469;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/solarized-light.rstheme
+++ b/inst/themes/solarized-light.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: Solarized Light {rsthemes} */
 /* rs-theme-is-dark: FALSE */
@@ -22,26 +22,26 @@
   color: #657b83;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #fdf6e3;
   color: #657b83;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #fdf6e3;
   color: #657b83;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #fdf6e3;
   color: #657b83;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #657b83;
 }
 
@@ -276,134 +276,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #fefbf1 !important;
   color: #657b83 !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #fefbf1 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #fefbf1;
   border-color: #fdf6e3;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #fdf6e3;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #fdf6e3 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #93a1a1;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #eee8d5 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #586e75;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #fdf6e3 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #eee8d5 !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #586e75 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #eee8d5 !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #cb4b16;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #eee8d5 !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #fdf6e3 !important;
   color: #657b83 !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #657b83 !important;
   background: #93a1a1 !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px rgba(220, 50, 47, 0.4);
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px rgba(220, 50, 47, 0.4);
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #fdf6e3;
   color: #657b83;
   border-color: rgba(220, 50, 47, 0.4);
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: rgba(220, 50, 47, 0.4);
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #fdf6e3;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #657b83;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #fdf6e3;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #93a1a1;
   color: #657b83;
 }
@@ -417,15 +417,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #fdf6e3 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #fdf6e3 !important;
 }
 
@@ -447,37 +447,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #eee8d5 rgba(253, 246, 227, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(253, 246, 227, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #eee8d5;
   border-radius: 0px;
   border: 2px solid #fdf6e3;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #f5f2e7;
 }
 
@@ -2624,35 +2624,49 @@ input#rstudio_command_palette_search {
   border-color: #fdf6e3;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #fdf6e3;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #fdf6e3;
   color: #657b83;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #fffefb;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: white;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/solarized-light.rstheme
+++ b/inst/themes/solarized-light.rstheme
@@ -22,26 +22,26 @@
   color: #657b83;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #fdf6e3;
   color: #657b83;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #fdf6e3;
   color: #657b83;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #fdf6e3;
   color: #657b83;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #657b83;
 }
 
@@ -298,112 +298,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #fdf6e3 !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: #93a1a1;
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #eee8d5 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #586e75;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #fdf6e3 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #eee8d5 !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #586e75 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #eee8d5 !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #cb4b16;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #eee8d5 !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #fdf6e3 !important;
   color: #657b83 !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #657b83 !important;
   background: #93a1a1 !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px rgba(220, 50, 47, 0.4);
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px rgba(220, 50, 47, 0.4);
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #fdf6e3;
   color: #657b83;
   border-color: rgba(220, 50, 47, 0.4);
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: rgba(220, 50, 47, 0.4);
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #fdf6e3;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #657b83;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #fdf6e3;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #93a1a1;
   color: #657b83;
 }
@@ -417,15 +417,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #fdf6e3 !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #fdf6e3 !important;
 }
 
@@ -447,37 +447,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #eee8d5 rgba(253, 246, 227, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(253, 246, 227, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #eee8d5;
   border-radius: 0px;
   border: 2px solid #fdf6e3;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #f5f2e7;
 }
 
@@ -2624,49 +2624,49 @@ input#rstudio_command_palette_search {
   border-color: #fdf6e3;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #fdf6e3;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #fdf6e3;
   color: #657b83;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #fffefb;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: white;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/yule-rstudio-reduced-motion.rstheme
+++ b/inst/themes/yule-rstudio-reduced-motion.rstheme
@@ -17,26 +17,26 @@
   color: #ede0ce;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #262c33;
   color: #ede0ce;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #262c33;
   color: #ede0ce;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #262c33;
   color: #ede0ce;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #ede0ce;
 }
 
@@ -293,112 +293,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #1f242a !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: rgba(237, 224, 206, 0.6);
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #2e343a !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ede0ce;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #1f242a !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #2e343a !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #ede0ce !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #2e343a !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #58cbca;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #2e343a !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #262c33 !important;
   color: #ede0ce !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #ede0ce !important;
   background: #3f7c7f !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #808080;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #808080;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #262c33;
   color: #ede0ce;
   border-color: #808080;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #808080;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #262c33;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #ede0ce;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #262c33;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #3f7c7f;
   color: #ede0ce;
 }
@@ -412,15 +412,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #1f242a !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #1f242a !important;
 }
 
@@ -442,37 +442,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #21262c rgba(38, 44, 51, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(38, 44, 51, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #21262c;
   border-radius: 0px;
   border: 2px solid #262c33;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #2c333b;
 }
 
@@ -2629,49 +2629,49 @@ input#rstudio_command_palette_search {
   border-color: #262c33;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #262c33;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #262c33;
   color: #ede0ce;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #365e62;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3c7275;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/yule-rstudio-reduced-motion.rstheme
+++ b/inst/themes/yule-rstudio-reduced-motion.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: Yule RStudio (Reduced Motion) {rsthemes} */
 /* rs-theme-is-dark: TRUE */
@@ -17,26 +17,26 @@
   color: #ede0ce;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #262c33;
   color: #ede0ce;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #262c33;
   color: #ede0ce;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #262c33;
   color: #ede0ce;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #ede0ce;
 }
 
@@ -271,134 +271,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #1b1f24 !important;
   color: #ede0ce !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #1b1f24 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #1b1f24;
   border-color: #262c33;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #262c33;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #1f242a !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: rgba(237, 224, 206, 0.6);
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #2e343a !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ede0ce;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #1f242a !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #2e343a !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #ede0ce !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #2e343a !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #58cbca;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #2e343a !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #262c33 !important;
   color: #ede0ce !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #ede0ce !important;
   background: #3f7c7f !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #808080;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #808080;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #262c33;
   color: #ede0ce;
   border-color: #808080;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #808080;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #262c33;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #ede0ce;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #262c33;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #3f7c7f;
   color: #ede0ce;
 }
@@ -412,15 +412,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #1f242a !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #1f242a !important;
 }
 
@@ -442,37 +442,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #21262c rgba(38, 44, 51, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(38, 44, 51, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #21262c;
   border-radius: 0px;
   border: 2px solid #262c33;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #2c333b;
 }
 
@@ -2629,35 +2629,49 @@ input#rstudio_command_palette_search {
   border-color: #262c33;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #262c33;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #262c33;
   color: #ede0ce;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #365e62;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3c7275;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/yule-rstudio-rsthemes.rstheme
+++ b/inst/themes/yule-rstudio-rsthemes.rstheme
@@ -17,26 +17,26 @@
   color: #ede0ce;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme {
+body.ace_editor_theme {
   background-color: #262c33;
   color: #ede0ce;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
+body.ace_editor_theme .profvis-flamegraph {
   background-color: #262c33;
   color: #ede0ce;
 }
 
-.rstudio-themes-dark-menus .ace_editor_theme {
+body .ace_editor_theme {
   background-color: #262c33;
   color: #ede0ce;
 }
 
-.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
+body.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-dark-menus .gwt-Label {
+body .gwt-Label {
   color: #ede0ce;
 }
 
@@ -293,112 +293,112 @@
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #1f242a !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: rgba(237, 224, 206, 0.6);
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .rstheme_center,
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #2e343a !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ede0ce;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+body .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #1f242a !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
+body .rstheme_toolbarWrapper {
   background: #2e343a !important;
 }
 
-.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
+body .rstheme_toolbarWrapper button, body .rstheme_toolbarWrapper a, body .rstheme_toolbarWrapper div {
   color: #ede0ce !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, body .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
+body .rstudio-themes-dark .search, bodybody .search {
   /* search */
   background: #2e343a !important;
 }
 
-.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+body #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #58cbca;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, body .rstudio-themes-dark-grey .dataGridHeader {
   background: #2e343a !important;
 }
 
 /* menu background */
-.rstudio-themes-dark-menus .popupMiddleCenter,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
+body .popupMiddleCenter,
+body .menuPopupMiddleCenter,
+body .suggestPopupMiddleCenter {
   background: #262c33 !important;
   color: #ede0ce !important;
 }
 
-.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
+body .popupMiddleCenter .item.item-selected,
+body .menuPopupMiddleCenter .item.item-selected,
+body .suggestPopupMiddleCenter .item.item-selected {
   color: #ede0ce !important;
   background: #3f7c7f !important;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel {
+body .themedPopupPanel {
   border: solid 1px #808080;
 }
 
-.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+body .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #808080;
 }
 
-.rstudio-themes-dark-menus .popupContent {
+body .popupContent {
   background: #262c33;
   color: #ede0ce;
   border-color: #808080;
 }
 
-.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+body .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
+body .popupContent + .rstudio-themes-scrollbars {
   border-color: #808080;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
+body .gwt-PopupPanel .popupContent {
   background: #262c33;
   padding: 2px;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
+body .gwt-PopupPanel .popupContent table {
   background: #ede0ce;
   border: 0;
 }
 
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
+body .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #262c33;
 }
 
-.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+bodybody .gwt-MenuItem.gwt-MenuItem-selected, bodybody .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #3f7c7f;
   color: #ede0ce;
 }
@@ -412,15 +412,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
+body .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #1f242a !important;
 }
 
-.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+body .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #1f242a !important;
 }
 
@@ -442,37 +442,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+body body .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, bodybody .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-dark-menus .ace_scroller {
+body .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
+body, body .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #21262c rgba(38, 44, 51, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+body ::-webkit-scrollbar, body .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+body *::-webkit-scrollbar-track, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(38, 44, 51, 0.5);
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+body *::-webkit-scrollbar-thumb, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #21262c;
   border-radius: 0px;
   border: 2px solid #262c33;
 }
 
-.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+body *::-webkit-scrollbar-thumb:hover, body .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #2c333b;
 }
 
@@ -2743,49 +2743,49 @@ input#rstudio_command_palette_search {
   border-color: #262c33;
 }
 
-.rstudio-themes-light-menus .rstudio-themes-border,
-.rstudio-themes-dark-menus .rstudio-themes-border {
+body .rstudio-themes-border,
+body .rstudio-themes-border {
   border-color: #262c33;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #262c33;
   color: #ede0ce;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #365e62;
 }
 
-.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
-.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+body .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3c7275;
 }
 
-.rstudio-themes-light-menus input#rstudio_command_palette_search,
-.rstudio-themes-dark-menus input#rstudio_command_palette_search {
+body input#rstudio_command_palette_search,
+body input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
+.js-focus-visible body input#rstudio_command_palette_search, .js-focus-visible body input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
-.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+body .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 

--- a/inst/themes/yule-rstudio-rsthemes.rstheme
+++ b/inst/themes/yule-rstudio-rsthemes.rstheme
@@ -1,4 +1,4 @@
-/* rsthemes 0.3.0 */
+/* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: Yule RStudio {rsthemes} */
 /* rs-theme-is-dark: TRUE */
@@ -17,26 +17,26 @@
   color: #ede0ce;
 }
 
-.rstudio-themes-flat.ace_editor_theme {
+.rstudio-themes-dark-menus.ace_editor_theme {
   background-color: #262c33;
   color: #ede0ce;
 }
 
-.rstudio-themes-flat.ace_editor_theme .profvis-flamegraph {
+.rstudio-themes-dark-menus.ace_editor_theme .profvis-flamegraph {
   background-color: #262c33;
   color: #ede0ce;
 }
 
-.rstudio-themes-flat .ace_editor_theme {
+.rstudio-themes-dark-menus .ace_editor_theme {
   background-color: #262c33;
   color: #ede0ce;
 }
 
-.rstudio-themes-flat.editor_dark.ace_editor_theme a {
+.rstudio-themes-dark-menus.editor_dark.ace_editor_theme a {
   color: #FFF !important;
 }
 
-.rstudio-themes-flat .gwt-Label {
+.rstudio-themes-dark-menus .gwt-Label {
   color: #ede0ce;
 }
 
@@ -271,134 +271,134 @@
 
 /* ---- RStudio Theme ---- */
 /* background */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark {
   background: #1b1f24 !important;
   color: #ede0ce !important;
   /* collapsed toolbar on rstudio server */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background {
+.rstudio-themes-dark .rstudio-themes-background {
   background: #1b1f24 !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey [role="banner"] + [role="navigation"] > table > tbody > tr > td,
-.rstudio-themes-flat .rstudio-themes-dark-grey header + [role="navigation"] > table > tbody > tr > td {
+.rstudio-themes-dark [role="banner"] + [role="navigation"] > table > tbody > tr > td,
+.rstudio-themes-dark header + [role="navigation"] > table > tbody > tr > td {
   background: #1b1f24;
   border-color: #262c33;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-border {
+.rstudio-themes-dark .rstudio-themes-border {
   border-color: #262c33;
 }
 
 /* inactive tabs */
 table.rstheme_tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstheme_multiPodUtilityTabArea {
   background: #1f242a !important;
 }
 
 table.rstheme_tabLayoutCenter .gwt-Label,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
   color: rgba(237, 224, 206, 0.6);
 }
 
 /* toolbar and selected tab */
-.rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_center,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .rstheme_center,
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.rstheme_tabLayoutCenter {
   background: #2e343a !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab-selected .gwt-Label {
   color: #ede0ce;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-TabLayoutPanelTab:hover .rstheme_tabLayoutCenter {
   background: #1f242a !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper {
   background: #2e343a !important;
 }
 
-.rstudio-themes-flat .rstheme_toolbarWrapper button, .rstudio-themes-flat .rstheme_toolbarWrapper a, .rstudio-themes-flat .rstheme_toolbarWrapper div {
+.rstudio-themes-dark-menus .rstheme_toolbarWrapper button, .rstudio-themes-dark-menus .rstheme_toolbarWrapper a, .rstudio-themes-dark-menus .rstheme_toolbarWrapper div {
   color: #ede0ce !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
   /* spliters */
   background: transparent !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .search, .rstudio-themes-flat.rstudio-themes-dark-menus .search {
+.rstudio-themes-dark-menus .rstudio-themes-dark .search, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .search {
   /* search */
   background: #2e343a !important;
 }
 
-.rstudio-themes-flat #rstudio_workbench_panel_find_in_files td[colspan="2"] {
+.rstudio-themes-dark-menus #rstudio_workbench_panel_find_in_files td[colspan="2"] {
   /* file name in Find in Files */
   color: #58cbca;
 }
 
 /* pane toolbars */
-.rstheme_secondaryToolbar, .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
+.rstheme_secondaryToolbar, .rstudio-themes-dark-menus .rstudio-themes-dark-grey .dataGridHeader {
   background: #2e343a !important;
 }
 
 /* menu background */
-.rstudio-themes-flat .popupMiddleCenter,
-.rstudio-themes-flat .menuPopupMiddleCenter,
-.rstudio-themes-flat .suggestPopupMiddleCenter {
+.rstudio-themes-dark-menus .popupMiddleCenter,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter {
   background: #262c33 !important;
   color: #ede0ce !important;
 }
 
-.rstudio-themes-flat .popupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .menuPopupMiddleCenter .item.item-selected,
-.rstudio-themes-flat .suggestPopupMiddleCenter .item.item-selected {
+.rstudio-themes-dark-menus .popupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .menuPopupMiddleCenter .item.item-selected,
+.rstudio-themes-dark-menus .suggestPopupMiddleCenter .item.item-selected {
   color: #ede0ce !important;
   background: #3f7c7f !important;
 }
 
-.rstudio-themes-flat .themedPopupPanel {
+.rstudio-themes-dark-menus .themedPopupPanel {
   border: solid 1px #808080;
 }
 
-.rstudio-themes-flat .themedPopupPanel ~ div.popupContent div:nth-child(1) {
+.rstudio-themes-dark-menus .themedPopupPanel ~ div.popupContent div:nth-child(1) {
   border: solid 1px #808080;
 }
 
-.rstudio-themes-flat .popupContent {
+.rstudio-themes-dark-menus .popupContent {
   background: #262c33;
   color: #ede0ce;
   border-color: #808080;
 }
 
-.rstudio-themes-flat .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
+.rstudio-themes-dark-menus .popupContent:not(.popupMiddleCenterInner) div div:nth-child(2) {
   background-color: unset;
   border: none;
 }
 
-.rstudio-themes-flat .popupContent + .rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus .popupContent + .rstudio-themes-scrollbars {
   border-color: #808080;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent {
   background: #262c33;
   padding: 2px;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table {
   background: #ede0ce;
   border: 0;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent table .gwt-Label {
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent table .gwt-Label {
   color: #262c33;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
+.rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected > table {
   background: #3f7c7f;
   color: #ede0ce;
 }
@@ -412,15 +412,15 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 }
 
 /* hacky toolbars section */
-.rstudio-themes-flat .rstudio-themes-dark-grey {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey {
   /* this next one might not be needed anymore (at least after 1.4+) */
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div > div > div:not(.gwt-TabLayoutPanelTabs) {
   background: #1f242a !important;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
+.rstudio-themes-dark-menus .rstudio-themes-dark-grey .windowframe > div:last-child > div > div > div:nth-child(3) > div {
   background: #1f242a !important;
 }
 
@@ -442,37 +442,37 @@ table.rstheme_tabLayoutCenter .gwt-Label,
 
 /* scrollbars */
 /* reset scrollbar background color */
-.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-dark-menus .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar, .rstudio-themes-dark-menus.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
   background-color: unset;
 }
 
-.rstudio-themes-flat .ace_scroller {
+.rstudio-themes-dark-menus .ace_scroller {
   overflow: visible;
 }
 
-.rstudio-themes-flat, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars {
+.rstudio-themes-dark-menus, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars {
   /* Works on Firefox */
   scrollbar-width: auto;
   scrollbar-color: #21262c rgba(38, 44, 51, 0.5);
   /* Works on Chrome, Edge, and Safari */
 }
 
-.rstudio-themes-flat ::-webkit-scrollbar, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-dark-menus ::-webkit-scrollbar, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
   width: auto;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-track, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-track, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-track {
   background: rgba(38, 44, 51, 0.5);
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb {
   background-color: #21262c;
   border-radius: 0px;
   border: 2px solid #262c33;
 }
 
-.rstudio-themes-flat *::-webkit-scrollbar-thumb:hover, .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
+.rstudio-themes-dark-menus *::-webkit-scrollbar-thumb:hover, .rstudio-themes-dark-menus .rstudio-themes-dark.rstudio-themes-scrollbars *::-webkit-scrollbar-thumb:hover {
   background-color: #2c333b;
 }
 
@@ -2743,35 +2743,49 @@ input#rstudio_command_palette_search {
   border-color: #262c33;
 }
 
-.rstudio-themes-flat .rstudio-themes-border {
+.rstudio-themes-light-menus .rstudio-themes-border,
+.rstudio-themes-dark-menus .rstudio-themes-border {
   border-color: #262c33;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"] table td {
   background-color: #262c33;
   color: #ede0ce;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [id*="rstudio_command_"]:hover table td {
   background-color: #365e62;
 }
 
-.rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-flat .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
+.rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"], .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label, .rstudio-themes-light-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] [id^="rstudio_command_entry"],
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table .gwt-Label,
+.rstudio-themes-dark-menus .gwt-PopupPanel .popupContent #rstudio_command_palette_list [aria-selected="true"] table td {
   background-color: #3c7275;
 }
 
-input#rstudio_command_palette_search {
+.rstudio-themes-light-menus input#rstudio_command_palette_search,
+.rstudio-themes-dark-menus input#rstudio_command_palette_search {
   padding: 10px 0;
   width: 580px;
   border: none;
 }
 
-.js-focus-visible input#rstudio_command_palette_search {
+.js-focus-visible .rstudio-themes-light-menus input#rstudio_command_palette_search, .js-focus-visible .rstudio-themes-dark-menus input#rstudio_command_palette_search {
   outline-offset: 5px !important;
 }
 
-.rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-flat .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
+.rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label, .rstudio-themes-light-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label,
+.rstudio-themes-dark-menus .popupContent [id^="rstudio_command"] [id^="rstudio_command_entry_"] .gwt-Label span {
   border: none;
 }
 


### PR DESCRIPTION
rsthemes doesn't work for the latest [Prairie Trillium daily builds](https://dailies.rstudio.com/rstudio/prairie-trillium/). The biggest change seems to be that the `.rstudio-themes-flat` on the top-level `<body>` element was removed. I've replaced that class with either `.rstudio-themes-light-menus` and `.rstudio-themes-dark-menus` but I'm not sure how far back those go