### PR TITLE
Increase text contrast on inactive tabs for base16 light themes

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -105,6 +105,8 @@ base16_prep_theme <- function(palette_file) {
     "base16-light_template.scss"
   }
 
+  rsthemes_version <- utils::packageVersion("rsthemes")
+
   whisker::whisker.render(
     readLines(package_template("base16", base16_template), warn = FALSE)
   )

--- a/inst/templates/base16/base16-dark_template.scss
+++ b/inst/templates/base16/base16-dark_template.scss
@@ -1,3 +1,5 @@
+/* rsthemes {{rsthemes_version}} */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 {{base16_name}} {rsthemes} */
 
 @import "palettes/base16/{{base16_palette}}";

--- a/inst/templates/base16/base16-light_template.scss
+++ b/inst/templates/base16/base16-light_template.scss
@@ -29,7 +29,7 @@ $ui_fold_arrows_foreground     : $ui_foreground;
 $ui_rstudio_background          : $base00;
 $ui_rstudio_foreground               : $ui_foreground;
 $ui_rstudio_tabs_inactive_background       : $base02;
-$ui_rstudio_tabs_inactive_foreground : $base03;
+$ui_rstudio_tabs_inactive_foreground : $base06;
 $ui_rstudio_tabs_active_background       : $base01;
 $ui_rstudio_tabs_active_foreground : $base05;
 $ui_rstudio_toolbar_background             : $ui_rstudio_tabs_active_background;

--- a/inst/templates/base16/base16-light_template.scss
+++ b/inst/templates/base16/base16-light_template.scss
@@ -1,3 +1,5 @@
+/* rsthemes {{rsthemes_version}} */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 {{base16_name}} {rsthemes} */
 
 @import "palettes/base16/{{base16_palette}}";

--- a/inst/themes/base16/base16-3024.rstheme
+++ b/inst/themes/base16/base16-3024.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 3024 {rsthemes} */
 /* 3024 by Jan T. Sott (http://github.com/idleberg) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-apathy.rstheme
+++ b/inst/themes/base16/base16-apathy.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Apathy {rsthemes} */
 /* Apathy by Jannik Siebert (https://github.com/janniks) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-ashes.rstheme
+++ b/inst/themes/base16/base16-ashes.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Ashes {rsthemes} */
 /* Ashes by Jannik Siebert (https://github.com/janniks) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-atelier-cave.rstheme
+++ b/inst/themes/base16/base16-atelier-cave.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Atelier Cave {rsthemes} */
 /* Atelier Cave by Bram de Haan (http://atelierbramdehaan.nl) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-atelier-dune.rstheme
+++ b/inst/themes/base16/base16-atelier-dune.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Atelier Dune {rsthemes} */
 /* Atelier Dune by Bram de Haan (http://atelierbramdehaan.nl) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-atelier-estuary.rstheme
+++ b/inst/themes/base16/base16-atelier-estuary.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Atelier Estuary {rsthemes} */
 /* Atelier Estuary by Bram de Haan (http://atelierbramdehaan.nl) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-atelier-forest.rstheme
+++ b/inst/themes/base16/base16-atelier-forest.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Atelier Forest {rsthemes} */
 /* Atelier Forest by Bram de Haan (http://atelierbramdehaan.nl) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-atelier-heath.rstheme
+++ b/inst/themes/base16/base16-atelier-heath.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Atelier Heath {rsthemes} */
 /* Atelier Heath by Bram de Haan (http://atelierbramdehaan.nl) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-atelier-lakeside.rstheme
+++ b/inst/themes/base16/base16-atelier-lakeside.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Atelier Lakeside {rsthemes} */
 /* Atelier Lakeside by Bram de Haan (http://atelierbramdehaan.nl) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-atelier-plateau.rstheme
+++ b/inst/themes/base16/base16-atelier-plateau.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Atelier Plateau {rsthemes} */
 /* Atelier Plateau by Bram de Haan (http://atelierbramdehaan.nl) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-atelier-savanna.rstheme
+++ b/inst/themes/base16/base16-atelier-savanna.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Atelier Savanna {rsthemes} */
 /* Atelier Savanna by Bram de Haan (http://atelierbramdehaan.nl) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-atelier-seaside.rstheme
+++ b/inst/themes/base16/base16-atelier-seaside.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Atelier Seaside {rsthemes} */
 /* Atelier Seaside by Bram de Haan (http://atelierbramdehaan.nl) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-atelier-sulphurpool.rstheme
+++ b/inst/themes/base16/base16-atelier-sulphurpool.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Atelier Sulphurpool {rsthemes} */
 /* Atelier Sulphurpool by Bram de Haan (http://atelierbramdehaan.nl) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-bespin.rstheme
+++ b/inst/themes/base16/base16-bespin.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Bespin {rsthemes} */
 /* Bespin by Jan T. Sott */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-brewer.rstheme
+++ b/inst/themes/base16/base16-brewer.rstheme
@@ -1,6 +1,8 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 @charset "UTF-8";
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Brewer {rsthemes} */
 /* Brewer by Timothée Poisot (http://github.com/tpoisot) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-bright.rstheme
+++ b/inst/themes/base16/base16-bright.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Bright {rsthemes} */
 /* Bright by Chris Kempson (http://chriskempson.com) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-chalk.rstheme
+++ b/inst/themes/base16/base16-chalk.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Chalk {rsthemes} */
 /* Chalk by Chris Kempson (http://chriskempson.com) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-codeschool.rstheme
+++ b/inst/themes/base16/base16-codeschool.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Codeschool {rsthemes} */
 /* Codeschool by brettof86 */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-cupcake.rstheme
+++ b/inst/themes/base16/base16-cupcake.rstheme
@@ -341,7 +341,7 @@ table.rstheme_tabLayoutCenter,
 table.rstheme_tabLayoutCenter .gwt-Label,
 .rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
-  color: #bfb9c6;
+  color: #72677E;
 }
 
 /* toolbar and selected tab */

--- a/inst/themes/base16/base16-cupcake.rstheme
+++ b/inst/themes/base16/base16-cupcake.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Cupcake {rsthemes} */
 /* Cupcake by Chris Kempson (http://chriskempson.com) */
 /* rs-theme-is-dark: FALSE */

--- a/inst/themes/base16/base16-darktooth.rstheme
+++ b/inst/themes/base16/base16-darktooth.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Darktooth {rsthemes} */
 /* Darktooth by Jason Milkins (https://github.com/jasonm23) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-default-dark.rstheme
+++ b/inst/themes/base16/base16-default-dark.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Default Dark {rsthemes} */
 /* Default Dark by Chris Kempson (http://chriskempson.com) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-default-light.rstheme
+++ b/inst/themes/base16/base16-default-light.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Default Light {rsthemes} */
 /* Default Light by Chris Kempson (http://chriskempson.com) */
 /* rs-theme-is-dark: FALSE */

--- a/inst/themes/base16/base16-default-light.rstheme
+++ b/inst/themes/base16/base16-default-light.rstheme
@@ -341,7 +341,7 @@ table.rstheme_tabLayoutCenter,
 table.rstheme_tabLayoutCenter .gwt-Label,
 .rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
-  color: #b8b8b8;
+  color: #282828;
 }
 
 /* toolbar and selected tab */

--- a/inst/themes/base16/base16-dracula.rstheme
+++ b/inst/themes/base16/base16-dracula.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Dracula {rsthemes} */
 /* Dracula by Mike Barkmin (http://github.com/mikebarkmin) based on Dracula Theme (http://github.com/dracula) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-eighties.rstheme
+++ b/inst/themes/base16/base16-eighties.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Eighties {rsthemes} */
 /* Eighties by Chris Kempson (http://chriskempson.com) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-embers.rstheme
+++ b/inst/themes/base16/base16-embers.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Embers {rsthemes} */
 /* Embers by Jannik Siebert (https://github.com/janniks) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-flat.rstheme
+++ b/inst/themes/base16/base16-flat.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Flat {rsthemes} */
 /* Flat by Chris Kempson (http://chriskempson.com) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-google-dark.rstheme
+++ b/inst/themes/base16/base16-google-dark.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Google Dark {rsthemes} */
 /* Google Dark by Seth Wright (http://sethawright.com) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-google-light.rstheme
+++ b/inst/themes/base16/base16-google-light.rstheme
@@ -341,7 +341,7 @@ table.rstheme_tabLayoutCenter,
 table.rstheme_tabLayoutCenter .gwt-Label,
 .rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
-  color: #b4b7b4;
+  color: #282a2e;
 }
 
 /* toolbar and selected tab */

--- a/inst/themes/base16/base16-google-light.rstheme
+++ b/inst/themes/base16/base16-google-light.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Google Light {rsthemes} */
 /* Google Light by Seth Wright (http://sethawright.com) */
 /* rs-theme-is-dark: FALSE */

--- a/inst/themes/base16/base16-grayscale-dark.rstheme
+++ b/inst/themes/base16/base16-grayscale-dark.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Grayscale Dark {rsthemes} */
 /* Grayscale Dark by Alexandre Gavioli (https://github.com/Alexx2/) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-grayscale-light.rstheme
+++ b/inst/themes/base16/base16-grayscale-light.rstheme
@@ -341,7 +341,7 @@ table.rstheme_tabLayoutCenter,
 table.rstheme_tabLayoutCenter .gwt-Label,
 .rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
-  color: #ababab;
+  color: #252525;
 }
 
 /* toolbar and selected tab */

--- a/inst/themes/base16/base16-grayscale-light.rstheme
+++ b/inst/themes/base16/base16-grayscale-light.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Grayscale Light {rsthemes} */
 /* Grayscale Light by Alexandre Gavioli (https://github.com/Alexx2/) */
 /* rs-theme-is-dark: FALSE */

--- a/inst/themes/base16/base16-green-screen.rstheme
+++ b/inst/themes/base16/base16-green-screen.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Green Screen {rsthemes} */
 /* Green Screen by Chris Kempson (http://chriskempson.com) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-gruvbox-dark-hard.rstheme
+++ b/inst/themes/base16/base16-gruvbox-dark-hard.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Gruvbox dark, hard {rsthemes} */
 /* Gruvbox dark, hard by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-gruvbox-dark-medium.rstheme
+++ b/inst/themes/base16/base16-gruvbox-dark-medium.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Gruvbox dark, medium {rsthemes} */
 /* Gruvbox dark, medium by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-gruvbox-dark-pale.rstheme
+++ b/inst/themes/base16/base16-gruvbox-dark-pale.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Gruvbox dark, pale {rsthemes} */
 /* Gruvbox dark, pale by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-gruvbox-dark-soft.rstheme
+++ b/inst/themes/base16/base16-gruvbox-dark-soft.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Gruvbox dark, soft {rsthemes} */
 /* Gruvbox dark, soft by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-gruvbox-light-hard.rstheme
+++ b/inst/themes/base16/base16-gruvbox-light-hard.rstheme
@@ -341,7 +341,7 @@ table.rstheme_tabLayoutCenter,
 table.rstheme_tabLayoutCenter .gwt-Label,
 .rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
-  color: #bdae93;
+  color: #3c3836;
 }
 
 /* toolbar and selected tab */

--- a/inst/themes/base16/base16-gruvbox-light-hard.rstheme
+++ b/inst/themes/base16/base16-gruvbox-light-hard.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Gruvbox light, hard {rsthemes} */
 /* Gruvbox light, hard by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox) */
 /* rs-theme-is-dark: FALSE */

--- a/inst/themes/base16/base16-gruvbox-light-medium.rstheme
+++ b/inst/themes/base16/base16-gruvbox-light-medium.rstheme
@@ -341,7 +341,7 @@ table.rstheme_tabLayoutCenter,
 table.rstheme_tabLayoutCenter .gwt-Label,
 .rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
-  color: #bdae93;
+  color: #3c3836;
 }
 
 /* toolbar and selected tab */

--- a/inst/themes/base16/base16-gruvbox-light-medium.rstheme
+++ b/inst/themes/base16/base16-gruvbox-light-medium.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Gruvbox light, medium {rsthemes} */
 /* Gruvbox light, medium by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox) */
 /* rs-theme-is-dark: FALSE */

--- a/inst/themes/base16/base16-gruvbox-light-soft.rstheme
+++ b/inst/themes/base16/base16-gruvbox-light-soft.rstheme
@@ -341,7 +341,7 @@ table.rstheme_tabLayoutCenter,
 table.rstheme_tabLayoutCenter .gwt-Label,
 .rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
-  color: #bdae93;
+  color: #3c3836;
 }
 
 /* toolbar and selected tab */

--- a/inst/themes/base16/base16-gruvbox-light-soft.rstheme
+++ b/inst/themes/base16/base16-gruvbox-light-soft.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Gruvbox light, soft {rsthemes} */
 /* Gruvbox light, soft by Dawid Kurek (dawikur@gmail.com), morhetz (https://github.com/morhetz/gruvbox) */
 /* rs-theme-is-dark: FALSE */

--- a/inst/themes/base16/base16-harmonic16-dark.rstheme
+++ b/inst/themes/base16/base16-harmonic16-dark.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Harmonic16 Dark {rsthemes} */
 /* Harmonic16 Dark by Jannik Siebert (https://github.com/janniks) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-harmonic16-light.rstheme
+++ b/inst/themes/base16/base16-harmonic16-light.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Harmonic16 Light {rsthemes} */
 /* Harmonic16 Light by Jannik Siebert (https://github.com/janniks) */
 /* rs-theme-is-dark: FALSE */

--- a/inst/themes/base16/base16-harmonic16-light.rstheme
+++ b/inst/themes/base16/base16-harmonic16-light.rstheme
@@ -341,7 +341,7 @@ table.rstheme_tabLayoutCenter,
 table.rstheme_tabLayoutCenter .gwt-Label,
 .rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
-  color: #aabcce;
+  color: #223b54;
 }
 
 /* toolbar and selected tab */

--- a/inst/themes/base16/base16-hopscotch.rstheme
+++ b/inst/themes/base16/base16-hopscotch.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Hopscotch {rsthemes} */
 /* Hopscotch by Jan T. Sott */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-ir-black.rstheme
+++ b/inst/themes/base16/base16-ir-black.rstheme
@@ -1,6 +1,8 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
 @charset "UTF-8";
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 IR Black {rsthemes} */
 /* IR Black by Timothée Poisot (http://timotheepoisot.fr) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-isotope.rstheme
+++ b/inst/themes/base16/base16-isotope.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Isotope {rsthemes} */
 /* Isotope by Jan T. Sott */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-london-tube.rstheme
+++ b/inst/themes/base16/base16-london-tube.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 London Tube {rsthemes} */
 /* London Tube by Jan T. Sott */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-macintosh.rstheme
+++ b/inst/themes/base16/base16-macintosh.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Macintosh {rsthemes} */
 /* Macintosh by Rebecca Bettencourt (http://www.kreativekorp.com) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-marrakesh.rstheme
+++ b/inst/themes/base16/base16-marrakesh.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Marrakesh {rsthemes} */
 /* Marrakesh by Alexandre Gavioli (http://github.com/Alexx2/) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-materia.rstheme
+++ b/inst/themes/base16/base16-materia.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Materia {rsthemes} */
 /* Materia by Defman21 */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-mexico-light.rstheme
+++ b/inst/themes/base16/base16-mexico-light.rstheme
@@ -341,7 +341,7 @@ table.rstheme_tabLayoutCenter,
 table.rstheme_tabLayoutCenter .gwt-Label,
 .rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
-  color: #b8b8b8;
+  color: #282828;
 }
 
 /* toolbar and selected tab */

--- a/inst/themes/base16/base16-mexico-light.rstheme
+++ b/inst/themes/base16/base16-mexico-light.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Mexico Light {rsthemes} */
 /* Mexico Light by Sheldon Johnson */
 /* rs-theme-is-dark: FALSE */

--- a/inst/themes/base16/base16-mocha.rstheme
+++ b/inst/themes/base16/base16-mocha.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Mocha {rsthemes} */
 /* Mocha by Chris Kempson (http://chriskempson.com) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-monokai.rstheme
+++ b/inst/themes/base16/base16-monokai.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Monokai {rsthemes} */
 /* Monokai by Wimer Hazenberg (http://www.monokai.nl) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-nord.rstheme
+++ b/inst/themes/base16/base16-nord.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Nord {rsthemes} */
 /* Nord by arcticicestudio */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-ocean.rstheme
+++ b/inst/themes/base16/base16-ocean.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Ocean {rsthemes} */
 /* Ocean by Chris Kempson (http://chriskempson.com) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-oceanicnext.rstheme
+++ b/inst/themes/base16/base16-oceanicnext.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 OceanicNext {rsthemes} */
 /* OceanicNext by https://github.com/voronianski/oceanic-next-color-scheme */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-onedark.rstheme
+++ b/inst/themes/base16/base16-onedark.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 OneDark {rsthemes} */
 /* OneDark by Lalit Magant (http://github.com/tilal6991) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-paraiso.rstheme
+++ b/inst/themes/base16/base16-paraiso.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Paraiso {rsthemes} */
 /* Paraiso by Jan T. Sott */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-phd.rstheme
+++ b/inst/themes/base16/base16-phd.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 PhD {rsthemes} */
 /* PhD by Hennig Hasemann (http://leetless.de/vim.html) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-pico.rstheme
+++ b/inst/themes/base16/base16-pico.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Pico {rsthemes} */
 /* Pico by PICO-8 (http://www.lexaloffle.com/pico-8.php) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-pop.rstheme
+++ b/inst/themes/base16/base16-pop.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Pop {rsthemes} */
 /* Pop by Chris Kempson (http://chriskempson.com) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-railscasts.rstheme
+++ b/inst/themes/base16/base16-railscasts.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Railscasts {rsthemes} */
 /* Railscasts by Ryan Bates (http://railscasts.com) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-rebecca.rstheme
+++ b/inst/themes/base16/base16-rebecca.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Rebecca {rsthemes} */
 /* Rebecca by Victor Borja (http://github.com/vic) based on Rebecca Theme (http://github.com/vic/rebecca-theme) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-seti-ui.rstheme
+++ b/inst/themes/base16/base16-seti-ui.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Seti UI {rsthemes} */
 /* Seti UI by  */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-shapeshifter.rstheme
+++ b/inst/themes/base16/base16-shapeshifter.rstheme
@@ -341,7 +341,7 @@ table.rstheme_tabLayoutCenter,
 table.rstheme_tabLayoutCenter .gwt-Label,
 .rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
-  color: #555555;
+  color: #040404;
 }
 
 /* toolbar and selected tab */

--- a/inst/themes/base16/base16-shapeshifter.rstheme
+++ b/inst/themes/base16/base16-shapeshifter.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Shapeshifter {rsthemes} */
 /* Shapeshifter by Tyler Benziger (http://tybenz.com) */
 /* rs-theme-is-dark: FALSE */

--- a/inst/themes/base16/base16-solar-flare.rstheme
+++ b/inst/themes/base16/base16-solar-flare.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Solar Flare {rsthemes} */
 /* Solar Flare by Chuck Harmston (https://chuck.harmston.ch) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-solarized-dark.rstheme
+++ b/inst/themes/base16/base16-solarized-dark.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Solarized Dark {rsthemes} */
 /* Solarized Dark by Ethan Schoonover (http://ethanschoonover.com/solarized) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-solarized-light.rstheme
+++ b/inst/themes/base16/base16-solarized-light.rstheme
@@ -341,7 +341,7 @@ table.rstheme_tabLayoutCenter,
 table.rstheme_tabLayoutCenter .gwt-Label,
 .rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
-  color: #839496;
+  color: #073642;
 }
 
 /* toolbar and selected tab */

--- a/inst/themes/base16/base16-solarized-light.rstheme
+++ b/inst/themes/base16/base16-solarized-light.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Solarized Light {rsthemes} */
 /* Solarized Light by Ethan Schoonover (http://ethanschoonover.com/solarized) */
 /* rs-theme-is-dark: FALSE */

--- a/inst/themes/base16/base16-spacemacs.rstheme
+++ b/inst/themes/base16/base16-spacemacs.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Spacemacs {rsthemes} */
 /* Spacemacs by Nasser Alshammari (https://github.com/nashamri/spacemacs-theme) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-summerfruit-dark.rstheme
+++ b/inst/themes/base16/base16-summerfruit-dark.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Summerfruit Dark {rsthemes} */
 /* Summerfruit Dark by Christopher Corley (http://christop.club/) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-summerfruit-light.rstheme
+++ b/inst/themes/base16/base16-summerfruit-light.rstheme
@@ -341,7 +341,7 @@ table.rstheme_tabLayoutCenter,
 table.rstheme_tabLayoutCenter .gwt-Label,
 .rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
-  color: #B0B0B0;
+  color: #151515;
 }
 
 /* toolbar and selected tab */

--- a/inst/themes/base16/base16-summerfruit-light.rstheme
+++ b/inst/themes/base16/base16-summerfruit-light.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Summerfruit Light {rsthemes} */
 /* Summerfruit Light by Christopher Corley (http://christop.club/) */
 /* rs-theme-is-dark: FALSE */

--- a/inst/themes/base16/base16-tomorrow-night.rstheme
+++ b/inst/themes/base16/base16-tomorrow-night.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Tomorrow Night {rsthemes} */
 /* Tomorrow Night by Chris Kempson (http://chriskempson.com) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-tomorrow.rstheme
+++ b/inst/themes/base16/base16-tomorrow.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Tomorrow {rsthemes} */
 /* Tomorrow by Chris Kempson (http://chriskempson.com) */
 /* rs-theme-is-dark: FALSE */

--- a/inst/themes/base16/base16-tomorrow.rstheme
+++ b/inst/themes/base16/base16-tomorrow.rstheme
@@ -341,7 +341,7 @@ table.rstheme_tabLayoutCenter,
 table.rstheme_tabLayoutCenter .gwt-Label,
 .rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
-  color: #8e908c;
+  color: #282a2e;
 }
 
 /* toolbar and selected tab */

--- a/inst/themes/base16/base16-twilight.rstheme
+++ b/inst/themes/base16/base16-twilight.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Twilight {rsthemes} */
 /* Twilight by David Hart (https://github.com/hartbit) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-unikitty-dark.rstheme
+++ b/inst/themes/base16/base16-unikitty-dark.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Unikitty Dark {rsthemes} */
 /* Unikitty Dark by Josh W Lewis (@joshwlewis) */
 /* rs-theme-is-dark: TRUE */

--- a/inst/themes/base16/base16-unikitty-light.rstheme
+++ b/inst/themes/base16/base16-unikitty-light.rstheme
@@ -341,7 +341,7 @@ table.rstheme_tabLayoutCenter,
 table.rstheme_tabLayoutCenter .gwt-Label,
 .rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-Label,
 .rstheme_multiPodUtilityTabArea .gwt-Label {
-  color: #a7a5a8;
+  color: #4f4b51;
 }
 
 /* toolbar and selected tab */

--- a/inst/themes/base16/base16-unikitty-light.rstheme
+++ b/inst/themes/base16/base16-unikitty-light.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Unikitty Light {rsthemes} */
 /* Unikitty Light by Josh W Lewis (@joshwlewis) */
 /* rs-theme-is-dark: FALSE */

--- a/inst/themes/base16/base16-woodland.rstheme
+++ b/inst/themes/base16/base16-woodland.rstheme
@@ -1,5 +1,7 @@
 /* rsthemes 0.3.1 */
 /* https://github.com/gadenbuie/rsthemes */
+/* rsthemes 0.3.1 */
+/* https://github.com/gadenbuie/rsthemes */
 /* rs-theme-name: base16 Woodland {rsthemes} */
 /* Woodland by Jay Cornwall (https://jcornwall.com) */
 /* rs-theme-is-dark: TRUE */


### PR DESCRIPTION
Darkens inactive tab text color for base16 light themes to improve readability.
The text color on inactive tabs now uses `$base06` instead of `$base03`.

Closes #92.