### PR TITLE
Use is_hms() function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rsthemes
 Title: Full Themes for RStudio v1.2+
-Version: 0.5.0
+Version: 0.5.1
 Authors@R: c(
     person("Garrick", "Aden-Buie", , "garrick@adenbuie.com", role = c("aut", "cre")),
     person("Eric", "Hunt", , "52219938+eric-hunt@users.noreply.github.com", role = "ctb",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ BugReports: https://github.com/gadenbuie/rsthemes/issues
 Imports:
     cli,
     fs (>= 1.3.0),
-    hms,
+    hms (>= 0.5.0),
     purrr,
     rstudioapi (>= 0.9.0),
     sass (>= 0.2.1),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rsthemes 0.5.1
+
+- Use `is_hms()` in place of the deprecated `is.hms()`.
+
 # rsthemes 0.5.0
 
 - New theme(s) [Rosé Pine](https://rosepinetheme.com/) (@eric-hunt #102)

--- a/R/auto.R
+++ b/R/auto.R
@@ -284,7 +284,9 @@ choose_theme <- function(dark, now = hms::as_hms(Sys.time())) {
 }
 
 parse_hm <- function(x) {
-  if (hms::is.hms(x)) return(x)
+  if (hms::is_hms(x)) {
+    return(x)
+  }
   if (is.character(x)) {
     x <- hms::parse_hm(x)
     if (is.na(x)) {


### PR DESCRIPTION
Hi @gadenbuie 
Here is a quick fix for the function name change in `{hms}`.

Please let me know if anything else needs changing for this PR to merge.

## Description

is.hms() was deprecated in hms 1.2.0 and throws a lifecycle warning when using the package. This fixes that issue.
This PR fixes #107 .

## Warning
```
`is.hms()` was deprecated in hms 1.2.0.
ℹ Please use `is_hms()` instead.
ℹ The deprecated feature was likely used in the rsthemes package.
  Please report the issue at <https://github.com/gadenbuie/rsthemes/issues>.
This warning is displayed once every 8 hours.
Call `lifecycle::last_lifecycle_warnings()` to see where this warning was generated. 
```